### PR TITLE
feat(aws-agentic-ai): add Agent Registry, Evaluations, S3 Files deployment, and security docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AWS development skills for Claude Code including CDK, serverless architecture, cost optimization, and Bedrock AgentCore for AI agent deployment",
-    "version": "2.3.0"
+    "version": "2.4.0"
   },
   "plugins": [
     {
@@ -131,8 +131,8 @@
     },
     {
       "name": "aws-agentic-ai",
-      "description": "AWS Bedrock AgentCore comprehensive expert for deploying and managing all AgentCore services including Gateway, Runtime, Memory, Identity, Code Interpreter, Browser, and Observability",
-      "version": "1.3.0",
+      "description": "AWS Bedrock AgentCore comprehensive expert for deploying and managing all AgentCore services including Gateway, Runtime, Memory, Identity, Code Interpreter, Browser, Observability, Agent Registry, and Evaluations",
+      "version": "1.4.0",
       "author": {
         "name": "Kane Zhu",
         "email": "me@kane.mx"
@@ -140,13 +140,25 @@
       "homepage": "https://github.com/zxkane/aws-skills",
       "repository": "https://github.com/zxkane/aws-skills",
       "license": "MIT",
-      "keywords": ["aws", "bedrock", "agentcore", "ai-agents", "mcp", "gateway", "runtime", "memory", "identity"],
+      "keywords": ["aws", "bedrock", "agentcore", "ai-agents", "mcp", "gateway", "runtime", "memory", "identity", "agent-registry", "discovery", "evaluations"],
       "category": "development",
       "source": "./plugins/aws-agentic-ai",
       "strict": false,
       "skills": [
         "./skills/aws-agentic-ai"
-      ]
+      ],
+      "mcpServers": {
+        "acdocs": {
+          "type": "stdio",
+          "command": "uvx",
+          "args": [
+            "awslabs.amazon-bedrock-agentcore-mcp-server@latest"
+          ],
+          "env": {
+            "FASTMCP_LOG_LEVEL": "ERROR"
+          }
+        }
+      }
     }
   ]
 }

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/SKILL.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/SKILL.md
@@ -2,7 +2,7 @@
 name: aws-agentic-ai
 aliases:
   - bedrock-agentcore
-description: This skill should be used when the user works with any AWS Bedrock AgentCore service including Gateway, Runtime, Memory, Identity, Code Interpreter, Browser, Observability, Agent Registry, Evaluations, or any AgentCore component. This skill should also be used when the user asks to "create a registry", "register an MCP server", "search agent registry", "approve registry record", "sync MCP server", "discover agents and tools", "evaluate agent", "create evaluator", "set up online evaluation", "deploy agent to runtime", "create gateway target", or "manage agent credentials".
+description: AWS Bedrock AgentCore comprehensive expert for deploying and managing AI agents at scale. Use when working with any AgentCore service including Gateway, Runtime, Memory, Identity, Code Interpreter, Browser, Observability, Agent Registry, or Evaluations. Covers agent deployment, MCP tool integration, credential management, agent discovery, governance workflows, and automated quality assessment. Essential when user mentions AgentCore, agent runtime, agent registry, agent evaluation, MCP gateway, deploy agent, register MCP server, discover agents, evaluate agent quality, agent credentials, or wants to build, deploy, catalog, or monitor AI agents on AWS.
 context: fork
 model: sonnet
 skills:
@@ -31,6 +31,8 @@ hooks:
 
 AWS Bedrock AgentCore provides a complete platform for deploying and scaling AI agents with nine core services. This skill covers service selection, deployment patterns, and integration workflows using AWS CLI.
 
+**How to use this skill**: Identify the service(s) the user needs from the table below, then read the corresponding service README before responding. For cross-service patterns (credentials, security, registry integration), check the Cross-Service Resources section. Verify AWS-specific details using the MCP documentation tools.
+
 ## AWS Documentation Requirement
 
 Always verify AWS facts using MCP tools before answering. Two documentation sources are available:
@@ -38,19 +40,6 @@ Always verify AWS facts using MCP tools before answering. Two documentation sour
 - **General AWS docs** (`mcp__aws-mcp__*` or `mcp__*awsdocs*__*`) — loaded via the `aws-mcp-setup` dependency for broader AWS documentation
 
 Prefer the AgentCore docs MCP for AgentCore-specific questions. If MCP tools are unavailable, guide the user through the `aws-mcp-setup` skill's setup flow.
-
-## When to Use This Skill
-
-Applicable scenarios:
-- Deploy REST APIs as MCP tools for AI agents (Gateway)
-- Execute agents in serverless runtime (Runtime)
-- Add conversation memory to agents (Memory)
-- Manage API credentials and authentication (Identity)
-- Enable agents to execute code securely (Code Interpreter)
-- Allow agents to interact with websites (Browser)
-- Monitor and trace agent performance (Observability)
-- Catalog, discover, and govern AI agents, MCP servers, and tools (Agent Registry)
-- Evaluate agent quality with LLM-as-a-Judge scoring (Evaluations)
 
 ## Available Services
 
@@ -70,21 +59,19 @@ Applicable scenarios:
 
 ### Deploying a Gateway Target
 
-**MANDATORY - READ DETAILED DOCUMENTATION**: See [`services/gateway/README.md`](services/gateway/README.md) for complete Gateway setup guide including deployment strategies, troubleshooting, and IAM configuration.
+Read [`services/gateway/README.md`](services/gateway/README.md) before implementing — Gateway setup involves deployment strategies, IAM, and auth choices that vary significantly by use case.
 
-**Quick Workflow**:
 1. Upload OpenAPI schema to S3
 2. *(API Key auth only)* Create credential provider and store API key
 3. Create gateway target linking schema (and credentials if using API key)
 4. Verify target status and test connectivity
 
-> **Note**: Credential provider is only needed for API key authentication. Lambda targets use IAM roles, and MCP servers use OAuth.
+> Credential provider is only needed for API key authentication. Lambda targets use IAM roles, and MCP servers use OAuth.
 
 ### Managing Credentials
 
-**MANDATORY - READ DETAILED DOCUMENTATION**: See [`cross-service/credential-management.md`](cross-service/credential-management.md) for unified credential management patterns across all services.
+Read [`cross-service/credential-management.md`](cross-service/credential-management.md) first — credential patterns differ across services and getting them wrong causes hard-to-debug auth failures.
 
-**Quick Workflow**:
 1. Use Identity service credential providers for all API keys
 2. Link providers to gateway targets via ARN references
 3. Rotate credentials quarterly through credential provider updates
@@ -92,21 +79,19 @@ Applicable scenarios:
 
 ### Discovering Agents and Tools (Agent Registry)
 
-**MANDATORY - READ DETAILED DOCUMENTATION**: See [`services/registry/README.md`](services/registry/README.md) for complete Agent Registry guide including governance workflows, MCP endpoint configuration, and sync setup.
+Read [`services/registry/README.md`](services/registry/README.md) first — the registry has governance workflows, MCP endpoint options, and sync modes that affect how records become discoverable.
 
-**Quick Workflow**:
 1. Create a registry to catalog your organization's AI resources
 2. Register resources (MCP servers, agents, skills, custom) with descriptive metadata
 3. Submit records for approval (auto-approve for dev, manual for production)
 4. Search and discover approved resources via CLI or MCP endpoint
 
-> **Note**: Agent Registry is in Preview. Available in us-east-1, us-west-2, eu-west-1, ap-northeast-1, ap-southeast-2.
+> Agent Registry is in Preview. Available in us-east-1, us-west-2, eu-west-1, ap-northeast-1, ap-southeast-2.
 
 ### Evaluating Agent Quality
 
-**MANDATORY - READ DETAILED DOCUMENTATION**: See [`services/evaluations/README.md`](services/evaluations/README.md) for complete Evaluations guide including built-in/custom evaluators, online/on-demand modes, and IAM setup.
+Read [`services/evaluations/README.md`](services/evaluations/README.md) first — evaluators, scoring modes, and IAM setup vary between online monitoring and on-demand testing.
 
-**Quick Workflow**:
 1. Instrument the agent with OpenTelemetry (ADOT) for trace collection
 2. Create evaluators (use built-in like `Builtin.Helpfulness` or create custom)
 3. Set up online evaluation with sampling rate and data source
@@ -114,39 +99,16 @@ Applicable scenarios:
 
 ### Monitoring Agents
 
-**MANDATORY - READ DETAILED DOCUMENTATION**: See [`services/observability/README.md`](services/observability/README.md) for comprehensive monitoring setup.
+Read [`services/observability/README.md`](services/observability/README.md) for the full monitoring setup — observability configuration depends on your Runtime protocol and framework choice.
 
-**Quick Workflow**:
 1. Enable observability for agents
 2. Configure CloudWatch dashboards for metrics
 3. Set up alarms for error rates and latency
 4. Use X-Ray for distributed tracing
 
-## Service-Specific Documentation
+## Deep-Dive References
 
-For detailed documentation on each AgentCore service, see the following resources:
-
-### Gateway Service
-- **Overview**: [`services/gateway/README.md`](services/gateway/README.md)
-- **Deployment Strategies**: [`services/gateway/deployment-strategies.md`](services/gateway/deployment-strategies.md)
-- **Troubleshooting**: [`services/gateway/troubleshooting-guide.md`](services/gateway/troubleshooting-guide.md)
-
-### Agent Registry Service
-- **Overview**: [`services/registry/README.md`](services/registry/README.md)
-- **Getting Started**: [`services/registry/getting-started.md`](services/registry/getting-started.md)
-- **MCP Endpoint Guide**: [`services/registry/mcp-endpoint.md`](services/registry/mcp-endpoint.md)
-- **Governance Workflows**: [`services/registry/governance-workflows.md`](services/registry/governance-workflows.md)
-- **Sync Configuration**: [`services/registry/sync-configuration.md`](services/registry/sync-configuration.md)
-
-### Runtime, Memory, Identity, Code Interpreter, Browser, Observability, Evaluations
-Each service has comprehensive documentation in its respective directory:
-- [`services/runtime/README.md`](services/runtime/README.md)
-- [`services/memory/README.md`](services/memory/README.md)
-- [`services/identity/README.md`](services/identity/README.md)
-- [`services/code-interpreter/README.md`](services/code-interpreter/README.md)
-- [`services/browser/README.md`](services/browser/README.md)
-- [`services/observability/README.md`](services/observability/README.md)
-- [`services/evaluations/README.md`](services/evaluations/README.md)
+Each service README (linked in the table above) contains sub-links to getting-started guides, troubleshooting, and advanced topics. Start with the service README and follow pointers from there.
 
 ### Advanced Runtime & OAuth References
 

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/SKILL.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/SKILL.md
@@ -177,6 +177,7 @@ For patterns and best practices that span multiple AgentCore services:
 - **Credential Management**: [`cross-service/credential-management.md`](cross-service/credential-management.md) - Unified credential patterns, security practices, rotation procedures
 - **Registry Integration**: [`cross-service/registry-integration.md`](cross-service/registry-integration.md) - Cross-service patterns with Gateway, Identity, Runtime
 - **Security & Resource Policies**: [`cross-service/security-resource-policies.md`](cross-service/security-resource-policies.md) - Resource-based policies, cross-account access, VPC/IP restrictions
+- **Agent Deployment with S3 Files**: [`cross-service/agent-persistence-patterns.md`](cross-service/agent-persistence-patterns.md) - Deploy Strands Agents, OpenClaw, Claude Agent SDK on AgentCore with S3 Files and Session Storage
 
 ## Additional Resources
 

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/SKILL.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/SKILL.md
@@ -2,7 +2,7 @@
 name: aws-agentic-ai
 aliases:
   - bedrock-agentcore
-description: AWS Bedrock AgentCore comprehensive expert for deploying and managing all AgentCore services. Use when working with Gateway, Runtime, Memory, Identity, or any AgentCore component. Covers MCP target deployment, credential management, schema optimization, runtime configuration, memory management, and identity services.
+description: This skill should be used when the user works with any AWS Bedrock AgentCore service including Gateway, Runtime, Memory, Identity, Code Interpreter, Browser, Observability, Agent Registry, Evaluations, or any AgentCore component. This skill should also be used when the user asks to "create a registry", "register an MCP server", "search agent registry", "approve registry record", "sync MCP server", "discover agents and tools", "evaluate agent", "create evaluator", "set up online evaluation", "deploy agent to runtime", "create gateway target", or "manage agent credentials".
 context: fork
 model: sonnet
 skills:
@@ -10,6 +10,9 @@ skills:
 allowed-tools:
   - mcp__aws-mcp__*
   - mcp__awsdocs__*
+  - mcp__acdocs__search_agentcore_docs
+  - mcp__acdocs__fetch_agentcore_doc
+  - Bash(aws bedrock-agentcore *)
   - Bash(aws bedrock-agentcore-control *)
   - Bash(aws bedrock-agentcore-runtime *)
   - Bash(aws bedrock *)
@@ -26,15 +29,19 @@ hooks:
 
 # AWS Bedrock AgentCore
 
-AWS Bedrock AgentCore provides a complete platform for deploying and scaling AI agents with seven core services. This skill guides you through service selection, deployment patterns, and integration workflows using AWS CLI.
+AWS Bedrock AgentCore provides a complete platform for deploying and scaling AI agents with nine core services. This skill covers service selection, deployment patterns, and integration workflows using AWS CLI.
 
 ## AWS Documentation Requirement
 
-Always verify AWS facts using MCP tools (`mcp__aws-mcp__*` or `mcp__*awsdocs*__*`) before answering. The `aws-mcp-setup` dependency is auto-loaded — if MCP tools are unavailable, guide the user through that skill's setup flow.
+Always verify AWS facts using MCP tools before answering. Two documentation sources are available:
+- **AgentCore-specific docs** (`mcp__acdocs__*`) — bundled with this plugin, provides `search_agentcore_docs` and `fetch_agentcore_doc` for AgentCore documentation
+- **General AWS docs** (`mcp__aws-mcp__*` or `mcp__*awsdocs*__*`) — loaded via the `aws-mcp-setup` dependency for broader AWS documentation
+
+Prefer the AgentCore docs MCP for AgentCore-specific questions. If MCP tools are unavailable, guide the user through the `aws-mcp-setup` skill's setup flow.
 
 ## When to Use This Skill
 
-Use this skill when you need to:
+Applicable scenarios:
 - Deploy REST APIs as MCP tools for AI agents (Gateway)
 - Execute agents in serverless runtime (Runtime)
 - Add conversation memory to agents (Memory)
@@ -42,6 +49,8 @@ Use this skill when you need to:
 - Enable agents to execute code securely (Code Interpreter)
 - Allow agents to interact with websites (Browser)
 - Monitor and trace agent performance (Observability)
+- Catalog, discover, and govern AI agents, MCP servers, and tools (Agent Registry)
+- Evaluate agent quality with LLM-as-a-Judge scoring (Evaluations)
 
 ## Available Services
 
@@ -54,6 +63,8 @@ Use this skill when you need to:
 | **Code Interpreter** | Secure code execution in sandboxes | [`services/code-interpreter/README.md`](services/code-interpreter/README.md) |
 | **Browser** | Web automation and scraping | [`services/browser/README.md`](services/browser/README.md) |
 | **Observability** | Tracing and monitoring | [`services/observability/README.md`](services/observability/README.md) |
+| **Agent Registry** | Catalog, discover, and govern agents/tools (Preview) | [`services/registry/README.md`](services/registry/README.md) |
+| **Evaluations** | Automated agent quality assessment (LLM-as-a-Judge) | [`services/evaluations/README.md`](services/evaluations/README.md) |
 
 ## Common Workflows
 
@@ -79,6 +90,28 @@ Use this skill when you need to:
 3. Rotate credentials quarterly through credential provider updates
 4. Monitor usage with CloudWatch metrics
 
+### Discovering Agents and Tools (Agent Registry)
+
+**MANDATORY - READ DETAILED DOCUMENTATION**: See [`services/registry/README.md`](services/registry/README.md) for complete Agent Registry guide including governance workflows, MCP endpoint configuration, and sync setup.
+
+**Quick Workflow**:
+1. Create a registry to catalog your organization's AI resources
+2. Register resources (MCP servers, agents, skills, custom) with descriptive metadata
+3. Submit records for approval (auto-approve for dev, manual for production)
+4. Search and discover approved resources via CLI or MCP endpoint
+
+> **Note**: Agent Registry is in Preview. Available in us-east-1, us-west-2, eu-west-1, ap-northeast-1, ap-southeast-2.
+
+### Evaluating Agent Quality
+
+**MANDATORY - READ DETAILED DOCUMENTATION**: See [`services/evaluations/README.md`](services/evaluations/README.md) for complete Evaluations guide including built-in/custom evaluators, online/on-demand modes, and IAM setup.
+
+**Quick Workflow**:
+1. Instrument the agent with OpenTelemetry (ADOT) for trace collection
+2. Create evaluators (use built-in like `Builtin.Helpfulness` or create custom)
+3. Set up online evaluation with sampling rate and data source
+4. Monitor scores in CloudWatch dashboards; investigate low-scoring sessions
+
 ### Monitoring Agents
 
 **MANDATORY - READ DETAILED DOCUMENTATION**: See [`services/observability/README.md`](services/observability/README.md) for comprehensive monitoring setup.
@@ -98,7 +131,14 @@ For detailed documentation on each AgentCore service, see the following resource
 - **Deployment Strategies**: [`services/gateway/deployment-strategies.md`](services/gateway/deployment-strategies.md)
 - **Troubleshooting**: [`services/gateway/troubleshooting-guide.md`](services/gateway/troubleshooting-guide.md)
 
-### Runtime, Memory, Identity, Code Interpreter, Browser, Observability
+### Agent Registry Service
+- **Overview**: [`services/registry/README.md`](services/registry/README.md)
+- **Getting Started**: [`services/registry/getting-started.md`](services/registry/getting-started.md)
+- **MCP Endpoint Guide**: [`services/registry/mcp-endpoint.md`](services/registry/mcp-endpoint.md)
+- **Governance Workflows**: [`services/registry/governance-workflows.md`](services/registry/governance-workflows.md)
+- **Sync Configuration**: [`services/registry/sync-configuration.md`](services/registry/sync-configuration.md)
+
+### Runtime, Memory, Identity, Code Interpreter, Browser, Observability, Evaluations
 Each service has comprehensive documentation in its respective directory:
 - [`services/runtime/README.md`](services/runtime/README.md)
 - [`services/memory/README.md`](services/memory/README.md)
@@ -106,6 +146,7 @@ Each service has comprehensive documentation in its respective directory:
 - [`services/code-interpreter/README.md`](services/code-interpreter/README.md)
 - [`services/browser/README.md`](services/browser/README.md)
 - [`services/observability/README.md`](services/observability/README.md)
+- [`services/evaluations/README.md`](services/evaluations/README.md)
 
 ### Advanced Runtime & OAuth References
 
@@ -134,6 +175,8 @@ Production-ready templates in [`scripts/`](scripts/) for common deployment patte
 For patterns and best practices that span multiple AgentCore services:
 
 - **Credential Management**: [`cross-service/credential-management.md`](cross-service/credential-management.md) - Unified credential patterns, security practices, rotation procedures
+- **Registry Integration**: [`cross-service/registry-integration.md`](cross-service/registry-integration.md) - Cross-service patterns with Gateway, Identity, Runtime
+- **Security & Resource Policies**: [`cross-service/security-resource-policies.md`](cross-service/security-resource-policies.md) - Resource-based policies, cross-account access, VPC/IP restrictions
 
 ## Additional Resources
 

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/cross-service/agent-persistence-patterns.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/cross-service/agent-persistence-patterns.md
@@ -236,10 +236,10 @@ aws bedrock-agentcore-control create-agent-runtime \
 
 ```bash
 # 1. Create file system
-aws s3api create-file-system --bucket <bucket> --region <region>
+aws s3files create-file-system --bucket <bucket-arn> --role-arn <iam-role-arn> --region <region>
 
 # 2. Create mount target (one per AZ)
-aws s3api create-mount-target \
+aws s3files create-mount-target \
   --file-system-id <fs-id> \
   --subnet-id <subnet> \
   --security-groups <sg>
@@ -258,8 +258,8 @@ ls /mnt/s3-config/.claude/skills/
 ### IAM Requirements
 
 Compute role needs:
-- `s3:GetObject`, `s3:PutObject`, `s3:ListBucket` on the config bucket
-- `elasticfilesystem:ClientMount`, `elasticfilesystem:ClientWrite` on the file system
+- `s3:GetObject`, `s3:PutObject`, `s3:ListBucket` on the config bucket (for S3 intelligent read routing)
+- `s3files:ClientMount`, `s3files:ClientWrite` on the file system (for NFS client access)
 
 ### Security
 
@@ -271,7 +271,7 @@ Compute role needs:
 
 - [Runtime Service](../services/runtime/README.md) — Session Storage for AgentCore
 - [Memory Service](../services/memory/README.md) — AgentCore Memory for long-term recall
-- [Credential Management](credential-management.md) — IAM roles for S3/EFS access
+- [Credential Management](credential-management.md) — IAM roles for S3/S3 Files access
 - [S3 Files Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files.html)
 - [Claude Agent SDK — Skills](https://code.claude.com/docs/en/agent-sdk/skills)
 - [Claude Agent SDK — CLAUDE.md](https://code.claude.com/docs/en/agent-sdk/modifying-system-prompts)

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/cross-service/agent-persistence-patterns.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/cross-service/agent-persistence-patterns.md
@@ -1,0 +1,279 @@
+# Deploying Filesystem-Based Agent Frameworks with S3 Files and AgentCore
+
+**Applies to**: Runtime, S3 Files, Claude Agent SDK, OpenClaw, Strands Agents
+
+## Core Insight
+
+Modern agent frameworks discover capabilities by reading configuration files from the working directory at startup:
+
+| Framework | Key Config Files | Discovery Mechanism |
+|-----------|-----------------|---------------------|
+| **Claude Agent SDK** | `CLAUDE.md`, `.claude/skills/*/SKILL.md`, `.claude/commands/*.md`, `.claude/output-styles/*.md` | `cwd` + `setting_sources=["project"]` |
+| **OpenClaw** | `.openclaw/`, `.agents/`, `skills/`, `.codex`, `.env` | Gateway working directory |
+| **Strands Agents** | Agent code, `requirements.txt`, tool definitions | Python module loading |
+
+Modify a `SKILL.md` → agent gains new capabilities. Update `CLAUDE.md` → agent follows new guidelines. No redeployment.
+
+**S3 Files** mounts an S3 bucket as a shared NFS filesystem. All agent instances see identical configuration files. Update once in S3 → every instance picks it up on the next file access.
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────┐
+│  S3 Bucket (agent configuration source of truth)    │
+│                                                     │
+│  ├── CLAUDE.md                                      │
+│  ├── .claude/skills/*/SKILL.md                      │
+│  ├── .claude/commands/*.md                          │
+│  ├── .openclaw/skills/                              │
+│  └── shared-knowledge/                              │
+└─────────────┬───────────────────────────────────────┘
+              │ S3 Files NFS (auto bidirectional sync)
+              ▼
+┌─────────────────┐  ┌──────────────────┐  ┌──────────────┐
+│ EC2 / EKS / ECS │  │ EC2 / EKS / ECS  │  │ Lambda       │
+│ /mnt/s3-config/ │  │ /mnt/s3-config/  │  │ /mnt/s3/     │
+│ (Claude Agent)  │  │ (OpenClaw)       │  │ (Strands)    │
+└─────────────────┘  └──────────────────┘  └──────────────┘
+```
+
+**AgentCore Runtime** microVMs cannot mount S3 Files directly. For AgentCore deployments, pull shared config from S3 via API at session start, or use Session Storage for per-session file persistence.
+
+## Claude Agent SDK Deployment
+
+### With S3 Files (EC2/EKS)
+
+Point `cwd` to the S3 Files mount. The SDK reads `CLAUDE.md`, skills, commands, and output styles transparently:
+
+```python
+from claude_agent_sdk import query, ClaudeAgentOptions
+
+S3_MOUNT = "/mnt/s3-config"  # S3 Files mount point
+
+async def handle_request(prompt: str, session_id: str = None):
+    options = ClaudeAgentOptions(
+        cwd=S3_MOUNT,
+        setting_sources=["project"],
+        allowed_tools=["Skill", "Read", "Write", "Edit", "Bash", "Glob", "Grep"],
+    )
+    if session_id:
+        options.resume = session_id
+
+    async for message in query(prompt=prompt, options=options):
+        if hasattr(message, "result"):
+            yield message.result
+```
+
+Enable Bedrock model access (no Anthropic API key required):
+
+```bash
+export CLAUDE_CODE_USE_BEDROCK=1
+# AWS credentials from instance role
+```
+
+### Zero-Downtime Skill Updates
+
+Upload a new skill to S3 — all running instances discover it on next invocation without restart:
+
+```bash
+aws s3 cp ./api-testing/SKILL.md \
+  s3://agent-configs/.claude/skills/api-testing/SKILL.md
+```
+
+### On AgentCore Runtime (S3 API Sync)
+
+Pull shared config from S3 to Session Storage at session start:
+
+```python
+import boto3, os
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+from claude_agent_sdk import query, ClaudeAgentOptions
+import asyncio
+
+app = BedrockAgentCoreApp()
+s3 = boto3.client("s3")
+WORKSPACE = "/mnt/workspace"
+
+def sync_config():
+    """Pull shared agent config from S3 to local workspace."""
+    for prefix in ["CLAUDE.md", ".claude/skills/", ".claude/commands/"]:
+        if "/" not in prefix:
+            obj = s3.get_object(Bucket="agent-configs", Key=prefix)
+            path = f"{WORKSPACE}/{prefix}"
+            with open(path, "w") as f:
+                f.write(obj["Body"].read().decode())
+        else:
+            resp = s3.list_objects_v2(Bucket="agent-configs", Prefix=prefix)
+            for item in resp.get("Contents", []):
+                local = f"{WORKSPACE}/{item['Key']}"
+                os.makedirs(os.path.dirname(local), exist_ok=True)
+                obj = s3.get_object(Bucket="agent-configs", Key=item["Key"])
+                with open(local, "w") as f:
+                    f.write(obj["Body"].read().decode())
+
+@app.entrypoint
+def handler(payload):
+    sync_config()
+    async def run():
+        options = ClaudeAgentOptions(
+            cwd=WORKSPACE, setting_sources=["project"],
+            allowed_tools=["Skill", "Read", "Write", "Bash"],
+        )
+        result = None
+        async for msg in query(prompt=payload["prompt"], options=options):
+            if hasattr(msg, "result"):
+                result = msg.result
+        return result
+    return {"response": asyncio.run(run())}
+```
+
+## OpenClaw Deployment
+
+### With S3 Files (EKS)
+
+Mount two S3 file systems — shared config (read-only across pods) and per-user workspaces:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: openclaw
+        volumeMounts:
+        - name: shared-config
+          mountPath: /mnt/config    # Shared skills, prompts, templates
+          readOnly: true
+        - name: user-data
+          mountPath: /mnt/users     # Per-user workspaces
+      volumes:
+      - name: shared-config
+        nfs:
+          server: <fs-config>.s3-fs.<region>.amazonaws.com
+          path: /
+      - name: user-data
+        nfs:
+          server: <fs-users>.s3-fs.<region>.amazonaws.com
+          path: /
+```
+
+S3 Files provides automatic bidirectional sync — workspace writes propagate to S3 transparently. Per-user isolation is achieved through path-based separation (`/mnt/users/<user-id>/`).
+
+### On AgentCore Runtime
+
+Use Session Storage (`filesystemConfigurations`) for per-user workspace persistence. The Router maps each user to a stable `runtimeSessionId`, so the same user always resumes from the same filesystem state.
+
+## Strands Agents Deployment
+
+### With S3 Files (EC2/EKS) — Shared Knowledge Base
+
+```python
+from strands import Agent, tool
+from strands.models import BedrockModel
+from strands.session.s3_session_manager import S3SessionManager
+
+KNOWLEDGE = "/mnt/s3-knowledge"  # S3 Files mount
+
+@tool
+def search_docs(query: str, directory: str = "") -> str:
+    """Search shared reference documents.
+
+    Args:
+        query: Search term
+        directory: Subdirectory to scope search (e.g., 'policies')
+    """
+    import subprocess
+    path = f"{KNOWLEDGE}/{directory}" if directory else KNOWLEDGE
+    result = subprocess.run(
+        ["grep", "-rl", query, path, "--include=*.md"],
+        capture_output=True, text=True
+    )
+    return result.stdout or "No matching documents found."
+
+agent = Agent(
+    model=BedrockModel(model_id="us.anthropic.claude-sonnet-4-20250514-v1:0"),
+    tools=[search_docs],
+    session_manager=S3SessionManager(
+        session_id="user-123", bucket="agent-sessions", prefix="strands/"
+    ),
+)
+```
+
+### On AgentCore Runtime
+
+Use `S3SessionManager` for conversation persistence and Session Storage for file workspace:
+
+```bash
+aws bedrock-agentcore-control create-agent-runtime \
+  --agent-runtime-name "strands-agent" \
+  --filesystem-configurations '[{"sessionStorage": {"mountPath": "/mnt/workspace"}}]' \
+  ...
+```
+
+## Decision Matrix
+
+| Factor | S3 Files (EC2/EKS/ECS) | AgentCore + S3 API | AgentCore + Session Storage |
+|--------|------------------------|--------------------|-----------------------------|
+| **Shared config sync** | Native — update S3 once, all see it | Manual sync code at session start | Not shared (per-session) |
+| **Multi-instance sharing** | Native NFS | Not supported (per-microVM) | Not supported (per-session) |
+| **Per-user isolation** | Path-based (`/users/<id>/`) | Native (per-microVM) | Native (per-session) |
+| **File latency** | Sub-millisecond (small files) | 10-100ms (S3 API) | Sub-millisecond (local) |
+| **Ops complexity** | Medium (VPC, mount targets) | Low (fully managed) | Low (fully managed) |
+| **Claude Agent SDK** | `cwd` → mount point | Sync to Session Storage | `cwd` → Session Storage |
+| **Cost** | S3 + performance storage + access | Runtime + S3 API calls | Included in Runtime |
+
+### Recommended Deployments
+
+| Scenario | Target |
+|----------|--------|
+| Multi-instance shared skills/config | EC2/EKS + **S3 Files** |
+| Serverless per-user agent | **AgentCore Runtime** + Session Storage |
+| Claude Agent SDK production service | EC2/EKS + **S3 Files** (shared CLAUDE.md + skills) |
+| Large shared knowledge base | EC2/EKS + **S3 Files** (NFS access) |
+
+## S3 Files Setup
+
+```bash
+# 1. Create file system
+aws s3api create-file-system --bucket <bucket> --region <region>
+
+# 2. Create mount target (one per AZ)
+aws s3api create-mount-target \
+  --file-system-id <fs-id> \
+  --subnet-id <subnet> \
+  --security-groups <sg>
+
+# 3. Mount on compute
+sudo mount -t nfs4 <fs-id>.s3-fs.<region>.amazonaws.com:/ /mnt/s3-config
+
+# 4. Upload agent config
+aws s3 sync ./agent-config/ s3://<bucket>/
+
+# 5. Verify
+ls /mnt/s3-config/CLAUDE.md
+ls /mnt/s3-config/.claude/skills/
+```
+
+### IAM Requirements
+
+Compute role needs:
+- `s3:GetObject`, `s3:PutObject`, `s3:ListBucket` on the config bucket
+- `elasticfilesystem:ClientMount`, `elasticfilesystem:ClientWrite` on the file system
+
+### Security
+
+- S3 Files encrypts all data at rest (AWS KMS) and in transit (TLS)
+- Restrict NFS access to agent compute via VPC security groups
+- For multi-tenant deployments, use separate S3 prefixes per tenant
+
+## Related
+
+- [Runtime Service](../services/runtime/README.md) — Session Storage for AgentCore
+- [Memory Service](../services/memory/README.md) — AgentCore Memory for long-term recall
+- [Credential Management](credential-management.md) — IAM roles for S3/EFS access
+- [S3 Files Documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-files.html)
+- [Claude Agent SDK — Skills](https://code.claude.com/docs/en/agent-sdk/skills)
+- [Claude Agent SDK — CLAUDE.md](https://code.claude.com/docs/en/agent-sdk/modifying-system-prompts)
+- [OpenClaw](https://github.com/openclaw/openclaw)
+- [Strands Session Management](https://strandsagents.com/docs/user-guide/concepts/agents/session-management/)

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/cross-service/registry-integration.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/cross-service/registry-integration.md
@@ -1,0 +1,309 @@
+# Cross-Service: Registry Integration Patterns
+
+**Applies to**: Registry, Gateway, Runtime, Identity
+
+## Overview
+
+Agent Registry becomes most powerful when combined with other AgentCore services. This guide covers cross-service patterns for discovering, deploying, and operating AI resources through the registry.
+
+## Pattern 1: Registry + Gateway (Discover and Deploy MCP Servers)
+
+Discover MCP servers from the registry, then deploy them as Gateway targets for agent consumption.
+
+```
+┌──────────────┐  search   ┌──────────────┐  deploy   ┌──────────────┐
+│ Developer /  │ ────────> │ Agent        │ ────────> │ Gateway      │
+│ Agent        │           │ Registry     │           │ Target       │
+└──────────────┘           └──────────────┘           └──────────────┘
+                                  │                          │
+                                  │ MCP schema               │ serves tools
+                                  ▼                          ▼
+                           ┌──────────────┐           ┌──────────────┐
+                           │ External     │           │ AI Agents    │
+                           │ MCP Server   │           │ (consumers)  │
+                           └──────────────┘           └──────────────┘
+```
+
+### Workflow
+
+```bash
+REGION="us-east-1"
+REGISTRY_ID="reg-abc123"
+GATEWAY_ID="gw-xyz789"
+
+# 1. Search registry for a useful MCP server
+RESULT=$(aws bedrock-agentcore search-registry-records \
+  --search-query "payment processing" \
+  --registry-ids "arn:aws:bedrock-agentcore:${REGION}:$(aws sts get-caller-identity --query Account --output text):registry/${REGISTRY_ID}" \
+  --filter '{"descriptorType": {"$eq": "MCP"}}' \
+  --region $REGION)
+
+echo "$RESULT"
+# Extract the MCP server schema from the search results
+
+# 2. Save the discovered schema to S3
+echo "$RESULT" | jq -r '.records[0].descriptors.mcp.server.inlineContent' > /tmp/discovered-schema.json
+aws s3 cp /tmp/discovered-schema.json s3://my-schemas-bucket/discovered/payments-mcp.json
+
+# 3. Deploy as a Gateway target
+aws bedrock-agentcore-control create-gateway-target \
+  --gateway-identifier $GATEWAY_ID \
+  --name "payments-from-registry" \
+  --endpoint-configuration '{
+    "openApiSchema": {
+      "s3": {"uri": "s3://my-schemas-bucket/discovered/payments-mcp.json"}
+    }
+  }' \
+  --region $REGION
+```
+
+### Bi-directional Sync
+
+Register your Gateway targets back into the registry so other teams can discover them using URL-based sync:
+
+```bash
+# Sync a Gateway target into the registry
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id $REGISTRY_ID \
+  --name "platform/payments-gateway" \
+  --description "Payment tools exposed via Gateway (team: platform)" \
+  --descriptor-type MCP \
+  --synchronization-type URL \
+  --synchronization-configuration "{
+    \"fromUrl\": {
+      \"url\": \"https://bedrock-agentcore.${REGION}.amazonaws.com/gateway/${GATEWAY_ID}/target/tgt-payments/mcp\",
+      \"credentialProviderConfigurations\": [{
+        \"credentialProviderType\": \"IAM\",
+        \"credentialProvider\": {
+          \"iamCredentialProvider\": {
+            \"roleArn\": \"arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):role/RegistrySyncRole\",
+            \"service\": \"bedrock-agentcore\"
+          }
+        }
+      }]
+    }
+  }" \
+  --region $REGION
+```
+
+## Pattern 2: Registry + Identity (Credential-Aware Discovery)
+
+Use Identity service credentials when syncing from protected external sources.
+
+```
+┌──────────────┐           ┌──────────────┐           ┌──────────────┐
+│ Identity     │  provide  │ Registry     │  sync     │ External     │
+│ Service      │ ────────> │ Sync Engine  │ ────────> │ MCP Server   │
+│ (OAuth cred) │           │              │           │ (protected)  │
+└──────────────┘           └──────────────┘           └──────────────┘
+```
+
+### Setup
+
+```bash
+# 1. Create OAuth credential in Identity service
+aws bedrock-agentcore-control create-oauth-credential-provider \
+  --name "partner-api-oauth" \
+  --credential-provider-vendor CUSTOM \
+  --oauth-discovery '{"discoveryUrl": "https://auth.partner.com/.well-known/openid-configuration"}' \
+  --credential-provider-auth-parameters '{
+    "oauthParameters": {
+      "oauthClientId": "registry-sync-client",
+      "oauthClientSecret": "<CLIENT_SECRET>"
+    }
+  }' \
+  --region us-east-1
+
+# 2. Create synced record using the credential
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id <REGISTRY_ID> \
+  --name "partner/logistics-server" \
+  --descriptor-type MCP \
+  --synchronization-type URL \
+  --synchronization-configuration '{
+    "fromUrl": {
+      "url": "https://api.partner.com/mcp",
+      "credentialProviderConfigurations": [{
+        "credentialProviderType": "OAUTH",
+        "credentialProvider": {
+          "oauthCredentialProvider": {
+            "providerArn": "arn:aws:bedrock-agentcore:us-east-1:<account-id>:oauth-credential-provider/partner-api-oauth",
+            "grantType": "CLIENT_CREDENTIALS"
+          }
+        }
+      }]
+    }
+  }' \
+  --region us-east-1
+```
+
+## Pattern 3: Registry + Runtime (Dynamic Agent Composition)
+
+Agents running in Runtime can query the registry to dynamically discover and invoke other agents or tools.
+
+```
+┌──────────────┐  invoke   ┌──────────────┐  search   ┌──────────────┐
+│ User         │ ────────> │ Orchestrator │ ────────> │ Agent        │
+│              │           │ Agent        │           │ Registry     │
+└──────────────┘           │ (Runtime)    │           └──────┬───────┘
+                           └──────┬───────┘                  │
+                                  │                   discover│
+                                  │ invoke                   │
+                                  ▼                          ▼
+                           ┌──────────────┐           ┌──────────────┐
+                           │ Discovered   │ <──────── │ Agent Card   │
+                           │ Agent        │   A2A     │ (from record)│
+                           └──────────────┘           └──────────────┘
+```
+
+### Agent Code Example
+
+```python
+import boto3
+import json
+
+agentcore_client = boto3.client("bedrock-agentcore")
+agentcore_control = boto3.client("bedrock-agentcore-control")
+
+REGISTRY_ARN = "arn:aws:bedrock-agentcore:us-east-1:<account-id>:registry/reg-abc123"
+
+def discover_and_delegate(user_query: str) -> dict:
+    """Orchestrator agent discovers relevant agents/tools at runtime."""
+
+    # 1. Search registry for relevant capabilities
+    results = agentcore_client.search_registry_records(
+        searchQuery=user_query,
+        registryIds=[REGISTRY_ARN],
+        maxResults=5
+    )
+
+    # 2. Filter for agents or MCP servers
+    for record in results.get("records", []):
+        if record["descriptorType"] == "A2A":
+            # Parse A2A agent card
+            agent_card = json.loads(
+                record["descriptors"]["a2a"]["agentCard"]["inlineContent"]
+            )
+            # Invoke the discovered agent via its endpoint
+            return invoke_a2a_agent(agent_card["url"], user_query)
+
+        elif record["descriptorType"] == "MCP":
+            # Parse MCP server definition
+            mcp_def = json.loads(
+                record["descriptors"]["mcp"]["server"]["inlineContent"]
+            )
+            # Use the discovered tools
+            return invoke_mcp_tools(mcp_def, user_query)
+
+    return {"error": "No relevant agents or tools found"}
+```
+
+## Pattern 4: Multi-Registry Architecture
+
+Use multiple registries for different purposes, environments, or access levels.
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  Organization                        │
+│                                                      │
+│  ┌──────────────┐  ┌──────────────┐  ┌────────────┐│
+│  │ Dev Registry │  │ Prod Registry│  │ Partner    ││
+│  │ (auto-approve)│ │ (manual)     │  │ Registry   ││
+│  │              │  │              │  │ (JWT auth) ││
+│  │ - prototypes │  │ - validated  │  │ - external ││
+│  │ - experiments│  │ - production │  │ - partner  ││
+│  │ - draft tools│  │ - curated    │  │ - shared   ││
+│  └──────────────┘  └──────────────┘  └────────────┘│
+│                                                      │
+│  Promotion flow:  Dev ──> Prod ──> Partner          │
+└─────────────────────────────────────────────────────┘
+```
+
+### Promoting Records Across Registries
+
+```bash
+# 1. Read record from dev registry
+RECORD=$(aws bedrock-agentcore-control get-registry-record \
+  --registry-id $DEV_REGISTRY_ID \
+  --record-id $RECORD_ID \
+  --region us-east-1)
+
+# 2. Extract descriptor and create in prod registry
+DESCRIPTORS=$(echo "$RECORD" | jq '.descriptors')
+NAME=$(echo "$RECORD" | jq -r '.name')
+DESC=$(echo "$RECORD" | jq -r '.description')
+TYPE=$(echo "$RECORD" | jq -r '.descriptorType')
+
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id $PROD_REGISTRY_ID \
+  --name "$NAME" \
+  --description "$DESC" \
+  --descriptor-type "$TYPE" \
+  --descriptors "$DESCRIPTORS" \
+  --record-version "1.0.0" \
+  --region us-east-1
+
+# 3. Submit for prod approval
+aws bedrock-agentcore-control submit-registry-record-for-approval \
+  --registry-id $PROD_REGISTRY_ID \
+  --record-id $NEW_RECORD_ID \
+  --region us-east-1
+```
+
+## Security Considerations
+
+### Cross-Service IAM Policy
+
+A role that can discover resources and deploy them to Gateway:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "RegistrySearch",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:SearchRegistryRecords",
+        "bedrock-agentcore:InvokeRegistryMcp"
+      ],
+      "Resource": "arn:aws:bedrock-agentcore:*:*:registry/*"
+    },
+    {
+      "Sid": "RegistryRead",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:GetRegistryRecord",
+        "bedrock-agentcore:ListRegistryRecords"
+      ],
+      "Resource": "arn:aws:bedrock-agentcore:*:*:registry/*"
+    },
+    {
+      "Sid": "GatewayDeploy",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:CreateGatewayTarget",
+        "bedrock-agentcore:GetGatewayTarget"
+      ],
+      "Resource": "arn:aws:bedrock-agentcore:*:*:gateway/*"
+    }
+  ]
+}
+```
+
+### Least Privilege by Persona
+
+| Persona | Registry Permissions | Cross-Service Permissions |
+|---------|---------------------|--------------------------|
+| **Consumer** | `SearchRegistryRecords`, `InvokeRegistryMcp` | None required |
+| **Publisher** | + `CreateRegistryRecord`, `SubmitRegistryRecordForApproval` | None required |
+| **Curator** | + `UpdateRegistryRecordStatus` | None required |
+| **Platform Engineer** | + All Registry operations | Gateway, Runtime, Identity operations |
+
+## Related
+
+- [Registry Overview](../services/registry/README.md)
+- [Credential Management](credential-management.md)
+- [Gateway Service](../services/gateway/README.md)
+- [Identity Service](../services/identity/README.md)
+- [Runtime Service](../services/runtime/README.md)

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/cross-service/security-resource-policies.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/cross-service/security-resource-policies.md
@@ -1,0 +1,331 @@
+# Cross-Service: Security & Resource-Based Policies
+
+**Applies to**: Runtime, Gateway, Memory
+
+## Overview
+
+Resource-based policies allow attaching IAM-style policies directly to AgentCore resources to control which principals (AWS accounts, IAM users, or roles) can invoke and manage them. They work in conjunction with identity-based IAM policies.
+
+## Identity-Based vs Resource-Based Policies
+
+| Aspect | Identity-Based Policy | Resource-Based Policy |
+|--------|----------------------|----------------------|
+| **Attachment** | Attached to IAM users, roles, or groups | Attached directly to AgentCore resources |
+| **Management** | Managed through AWS IAM | Managed through AgentCore APIs |
+| **Specifies** | Actions and Resources (Principal is implicit) | Principals, Actions, and Conditions (Resource is implicit) |
+| **Use Case** | Define what an identity can do | Define who can access a resource |
+
+## Policy Evaluation Matrix
+
+When a request is made, AWS evaluates both identity-based and resource-based policies:
+
+| IAM Policy | Resource Policy | Result |
+|------------|----------------|--------|
+| Grants access | Silent | **Allowed** |
+| Grants access | Grants access | **Allowed** |
+| Grants access | Denies access | **Denied** |
+| Silent | Grants access | **Allowed** |
+| Silent | Silent | **Denied** |
+| Denies access | Any | **Denied** |
+
+Key principles:
+- **Explicit Deny always wins** — if any policy denies, access is denied regardless
+- **Either policy can allow** — if either permits and none denies, access is granted
+- **Default Deny** — if no policy explicitly permits, access is denied
+
+## Supported Resources
+
+| Resource | Supported Actions |
+|----------|-------------------|
+| **Agent Runtime** | Invoke, invoke for user, invoke command, WebSocket, stop session, get agent card |
+| **Agent Endpoint** | Same as Runtime (hierarchical authorization) |
+| **Gateway** | Invoke gateway |
+| **Memory** | CRUD operations on memory, events, records, sessions, actors, extraction jobs |
+
+## Hierarchical Authorization (Runtime + Endpoint)
+
+Agent endpoints are addressable access points to specific runtime versions. When authorizing invocations, AWS evaluates policies for **both** the runtime and the endpoint.
+
+For cross-account access, create resource-based policies on **both** resources:
+
+Policy for Agent Runtime (attached to `arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID`):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::<caller-account-id>:role/CrossAccountRole"
+      },
+      "Action": "bedrock-agentcore:InvokeAgentRuntime",
+      "Resource": "arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID"
+    }
+  ]
+}
+```
+
+Policy for Agent Endpoint (attached to `arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID/endpoint/ENDPOINTID`):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::<caller-account-id>:role/CrossAccountRole"
+      },
+      "Action": "bedrock-agentcore:InvokeAgentRuntime",
+      "Resource": "arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID/endpoint/ENDPOINTID"
+    }
+  ]
+}
+```
+
+> **Important**: If either resource denies access or lacks an explicit allow, the request is denied.
+
+## Authentication Type Considerations
+
+| Auth Type | Principal Element | Notes |
+|-----------|-------------------|-------|
+| **SigV4** | Specific AWS principals (`"AWS": "arn:aws:iam::..."`) | Evaluated with caller's IAM permissions |
+| **OAuth** | Must use wildcard (`"Principal": "*"`) | JWT tokens validated by Identity Service before policy evaluation; use condition keys to restrict |
+
+> **Constraint**: A Runtime or Gateway supports only one auth type (SigV4 OR OAuth), set at creation time.
+
+## IAM Action Reference
+
+### Agent Runtime Actions
+
+| Action | Description |
+|--------|-------------|
+| `bedrock-agentcore:InvokeAgentRuntime` | Invoke an agent runtime |
+| `bedrock-agentcore:InvokeAgentRuntimeForUser` | Invoke with user ID header |
+| `bedrock-agentcore:InvokeAgentRuntimeCommand` | Execute a shell command in active session |
+| `bedrock-agentcore:InvokeAgentRuntimeWithWebSocketStream` | Invoke with WebSocket stream |
+| `bedrock-agentcore:InvokeAgentRuntimeWithWebSocketStreamForUser` | WebSocket with user ID header |
+| `bedrock-agentcore:StopRuntimeSession` | Stop an active runtime session |
+| `bedrock-agentcore:GetAgentCard` | Retrieve agent card information |
+
+### Gateway Actions
+
+| Action | Description |
+|--------|-------------|
+| `bedrock-agentcore:InvokeGateway` | Invoke a gateway |
+
+### Memory Actions
+
+| Action | Description |
+|--------|-------------|
+| `bedrock-agentcore:GetMemory` | Retrieve a Memory resource |
+| `bedrock-agentcore:UpdateMemory` | Update a Memory resource |
+| `bedrock-agentcore:DeleteMemory` | Delete a Memory resource |
+| `bedrock-agentcore:CreateEvent` | Create an event |
+| `bedrock-agentcore:GetEvent` | Retrieve an event |
+| `bedrock-agentcore:DeleteEvent` | Delete an event |
+| `bedrock-agentcore:ListEvents` | List events |
+| `bedrock-agentcore:ListActors` | List actors |
+| `bedrock-agentcore:ListSessions` | List sessions |
+| `bedrock-agentcore:GetMemoryRecord` | Get a memory record |
+| `bedrock-agentcore:ListMemoryRecords` | List memory records |
+| `bedrock-agentcore:RetrieveMemoryRecords` | Search memory records |
+| `bedrock-agentcore:DeleteMemoryRecord` | Delete a memory record |
+| `bedrock-agentcore:BatchCreateMemoryRecords` | Batch create records |
+| `bedrock-agentcore:BatchUpdateMemoryRecords` | Batch update records |
+| `bedrock-agentcore:BatchDeleteMemoryRecords` | Batch delete records |
+| `bedrock-agentcore:StartMemoryExtractionJob` | Start extraction job |
+| `bedrock-agentcore:ListMemoryExtractionJobs` | List extraction jobs |
+
+## Policy Examples
+
+### Cross-Account Access
+
+Grant specific roles in another account access to invoke a runtime:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::<caller-account-id>:role/DeveloperRole",
+          "arn:aws:iam::<caller-account-id>:role/AdminRole"
+        ]
+      },
+      "Action": "bedrock-agentcore:InvokeAgentRuntime",
+      "Resource": "arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID"
+    }
+  ]
+}
+```
+
+### IP Address Restriction
+
+Block traffic from specific IP ranges:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::<caller-account-id>:role/ApplicationRole"
+      },
+      "Action": "bedrock-agentcore:InvokeAgentRuntime",
+      "Resource": "arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID"
+    },
+    {
+      "Effect": "Deny",
+      "Principal": {
+        "AWS": "arn:aws:iam::<caller-account-id>:role/ApplicationRole"
+      },
+      "Action": "bedrock-agentcore:InvokeAgentRuntime",
+      "Resource": "arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID",
+      "Condition": {
+        "IpAddress": {
+          "aws:SourceIp": ["192.0.2.0/24", "198.51.100.0/24"]
+        }
+      }
+    }
+  ]
+}
+```
+
+### VPC Restriction
+
+Allow traffic only from a specific VPC:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::<caller-account-id>:role/ApplicationRole"
+      },
+      "Action": "bedrock-agentcore:InvokeAgentRuntime",
+      "Resource": "arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID"
+    },
+    {
+      "Effect": "Deny",
+      "Principal": {
+        "AWS": "arn:aws:iam::<caller-account-id>:role/ApplicationRole"
+      },
+      "Action": "bedrock-agentcore:InvokeAgentRuntime",
+      "Resource": "arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID",
+      "Condition": {
+        "StringNotEquals": {
+          "aws:SourceVpc": "vpc-1a2b3c4d"
+        }
+      }
+    }
+  ]
+}
+```
+
+### OAuth with VPC Restriction
+
+For OAuth-authenticated resources, use wildcard principal with condition keys:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowOAuthFromVPC",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "bedrock-agentcore:InvokeAgentRuntime",
+      "Resource": "arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID",
+      "Condition": {
+        "StringEquals": {
+          "aws:SourceVpc": "vpc-1a2b3c4d"
+        }
+      }
+    }
+  ]
+}
+```
+
+> **Note**: Wildcard principal is **required** for OAuth. JWT tokens are validated by Identity Service before policy evaluation. Anonymous requests are rejected before reaching policy evaluation.
+
+## Managing Resource Policies
+
+### AWS CLI
+
+```bash
+# Create or update a resource policy
+aws bedrock-agentcore-control put-resource-policy \
+  --resource-arn arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID \
+  --policy file://policy.json
+
+# Get a resource policy
+aws bedrock-agentcore-control get-resource-policy \
+  --resource-arn arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID
+
+# Delete a resource policy
+aws bedrock-agentcore-control delete-resource-policy \
+  --resource-arn arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID
+```
+
+### Python SDK
+
+```python
+import boto3
+import json
+
+client = boto3.client('bedrock-agentcore-control', region_name='us-west-2')
+resource_arn = 'arn:aws:bedrock-agentcore:us-west-2:<resource-owner-account-id>:runtime/AGENTID'
+
+# Put resource policy
+policy = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {"AWS": "arn:aws:iam::<caller-account-id>:role/MyRole"},
+            "Action": "bedrock-agentcore:InvokeAgentRuntime",
+            "Resource": resource_arn
+        }
+    ]
+}
+
+client.put_resource_policy(
+    resourceArn=resource_arn,
+    policy=json.dumps(policy)
+)
+
+# Get resource policy
+response = client.get_resource_policy(resourceArn=resource_arn)
+print(response['policy'])
+
+# Delete resource policy
+client.delete_resource_policy(resourceArn=resource_arn)
+```
+
+> **Important**: The `Resource` field must contain the **exact ARN** of the resource the policy is attached to. Using `"Resource": "*"` results in a validation error.
+
+## Best Practices
+
+- **Least privilege** — grant only the specific actions needed
+- **Use conditions** — restrict by VPC, IP, or source account even when allowing access
+- **Audit regularly** — review resource policies alongside identity-based policies
+- **Cross-account requires both** — for Runtime, create policies on both the runtime AND endpoint
+- **OAuth requires wildcard** — use condition keys (`aws:SourceVpc`, `aws:SourceVpce`) to restrict
+- **No `Resource: *`** — always use the exact resource ARN
+
+## Related
+
+- [Credential Management](credential-management.md)
+- [Registry Integration](registry-integration.md)
+- [Runtime Service](../services/runtime/README.md)
+- [Gateway Service](../services/gateway/README.md)
+- [Memory Service](../services/memory/README.md)
+- [Security in AgentCore (AWS Docs)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/security.html)
+- [IAM Policy Examples (AWS Docs)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/security_iam_id-based-policy-examples.html)

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/evaluations/README.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/evaluations/README.md
@@ -1,0 +1,340 @@
+# Evaluations Service
+
+> **Status**: Available
+
+## Overview
+
+Amazon Bedrock AgentCore Evaluations provides automated assessment tools to measure how well agents perform specific tasks, handle edge cases, and maintain consistency across different inputs and contexts. It uses **LLM-as-a-Judge** techniques to score agent behavior using both built-in and custom evaluators.
+
+AgentCore Evaluations integrates with agent frameworks (**Strands Agents**, **LangGraph**) via instrumentation libraries (**OpenTelemetry**, **OpenInference**). Traces from agents are converted to a unified format and scored automatically.
+
+## Key Concepts
+
+### Evaluators
+
+Resources that define how agent output is assessed. Each evaluator has a unique ARN:
+
+- **Built-in**: `arn:aws:bedrock-agentcore:::evaluator/Builtin.Helpfulness` (public, all users)
+- **Custom**: `arn:aws:bedrock-agentcore:<region>:<account>:evaluator/<id>` (private, access-controlled)
+
+### Evaluation Types
+
+| Type | Description | Use Case |
+|------|-------------|----------|
+| **Online** | Continuously monitors live production traffic | Production quality monitoring |
+| **On-demand** | Evaluates specific spans/traces by ID | Debugging, issue investigation, build-time testing |
+
+### Traces and Spans
+
+- **Trace** — complete record of a single agent execution (contains one or more spans)
+- **Span** — individual operation within a trace (tool call, model invocation, etc.)
+- **Session** — logical grouping of related interactions from a single user/workflow
+- **Tool Call** — span representing an agent's invocation of an external function or API
+
+### LLM-as-a-Judge
+
+Evaluation method using a language model to assess output quality. Reference-free — relies on the model's internal knowledge rather than ground-truth data. Enables scalable, consistent, customizable qualitative assessments.
+
+## Built-in Evaluators
+
+Pre-configured evaluators that cannot be modified. Use their ID in format `Builtin.EvaluatorName`:
+
+| Evaluator | Description |
+|-----------|-------------|
+| `Builtin.Helpfulness` | Assesses how helpful the agent's response is |
+| `Builtin.GoalSuccessRate` | Measures end-to-end task completion correctness |
+
+Built-in evaluators support cross-region inference and use optimized prompt templates.
+
+> **Note**: Built-in evaluator configurations (model, prompt template) cannot be modified.
+
+## Custom Evaluators
+
+Define your own evaluator model, evaluation instructions, and scoring schemas tailored to your use cases.
+
+### Create a Custom Evaluator
+
+```bash
+aws bedrock-agentcore-control create-evaluator \
+  --evaluator-name "my-custom-evaluator" \
+  --description "Evaluates response accuracy for domain-specific questions" \
+  --region us-east-1
+```
+
+### Manage Custom Evaluators
+
+```bash
+# List evaluators
+aws bedrock-agentcore-control list-evaluators --region us-east-1
+
+# Get evaluator details
+aws bedrock-agentcore-control get-evaluator \
+  --evaluator-id <EVALUATOR_ID> --region us-east-1
+
+# Update evaluator
+aws bedrock-agentcore-control update-evaluator \
+  --evaluator-id <EVALUATOR_ID> --region us-east-1
+
+# Delete evaluator
+aws bedrock-agentcore-control delete-evaluator \
+  --evaluator-id <EVALUATOR_ID> --region us-east-1
+```
+
+> **Evaluator locking**: When an enabled online evaluation uses a custom evaluator, the evaluator is automatically locked — no modifications or deletions allowed. Clone a new evaluator if changes are needed.
+
+## Online Evaluation
+
+Continuously monitors deployed agents using live production traffic with configurable sampling and filtering.
+
+### Components
+
+1. **Session sampling and filtering** — percentage-based sampling (e.g., 10%) or conditional filters
+2. **Evaluators** — up to 10 per configuration (built-in + custom combined)
+3. **Monitoring and analysis** — aggregated scores in dashboards, quality trends, session investigation
+
+### Create with AgentCore CLI
+
+```bash
+agentcore add online-eval \
+  --name "my_eval_config" \
+  --runtime "my_agent_runtime" \
+  --evaluator "Builtin.GoalSuccessRate" "Builtin.Helpfulness" \
+  --sampling-rate 1.0 \
+  --enable-on-create
+```
+
+> **Note**: Run from inside an AgentCore project directory (created with `agentcore create`). Then run `agentcore deploy` to create it in your AWS account.
+
+### Create with AWS CLI
+
+```bash
+aws bedrock-agentcore-control create-online-evaluation-config \
+  --online-evaluation-config-name "my_eval_config" \
+  --description "Continuous evaluation of my agent" \
+  --rule '{"samplingConfig": {"samplingPercentage": 80.0}}' \
+  --data-source-config '{
+    "cloudWatchLogs": {
+      "logGroupNames": ["/aws/agentcore/my-agent-traces"],
+      "serviceNames": ["my_agent.DEFAULT"]
+    }
+  }' \
+  --evaluators '[{"evaluatorId": "Builtin.Helpfulness"}, {"evaluatorId": "Builtin.GoalSuccessRate"}]' \
+  --evaluation-execution-role-arn "arn:aws:iam::<ACCOUNT_ID>:role/AgentCoreEvaluationRole" \
+  --enable-on-create \
+  --region us-east-1
+```
+
+### Create with Python SDK
+
+```python
+from bedrock_agentcore_starter_toolkit import Evaluation
+
+eval_client = Evaluation()
+
+config = eval_client.create_online_config(
+    config_name="my_eval_config",
+    agent_id="agent_myagent-ABC123xyz",
+    sampling_rate=1.0,
+    evaluator_list=["Builtin.GoalSuccessRate", "Builtin.Helpfulness"],
+    config_description="Online Evaluation Config",
+    auto_create_execution_role=True,
+    enable_on_create=True
+)
+
+print(f"Config ID: {config['onlineEvaluationConfigId']}")
+```
+
+### Execution Control
+
+```bash
+# Pause a running evaluation
+agentcore pause online-eval "my_eval_config"
+
+# Resume a paused evaluation
+agentcore resume online-eval "my_eval_config"
+```
+
+Execution states:
+- **ENABLED** — actively processing traces and generating results
+- **DISABLED** — configuration exists but job is paused
+
+### Manage Online Evaluations
+
+```bash
+# List configurations
+aws bedrock-agentcore-control list-online-evaluation-configs --region us-east-1
+
+# Get configuration details
+aws bedrock-agentcore-control get-online-evaluation-config \
+  --online-evaluation-config-id <CONFIG_ID> --region us-east-1
+
+# Update configuration
+aws bedrock-agentcore-control update-online-evaluation-config \
+  --online-evaluation-config-id <CONFIG_ID> --region us-east-1
+
+# Delete configuration
+aws bedrock-agentcore-control delete-online-evaluation-config \
+  --online-evaluation-config-id <CONFIG_ID> --region us-east-1
+```
+
+## On-Demand Evaluation
+
+Targeted assessment of specific spans or traces at any time. Specify exact span/trace IDs to evaluate.
+
+**Use cases**:
+- Investigate specific customer interactions
+- Validate fixes for reported issues
+- Analyze historical data for quality improvements
+- Build-time testing during development
+
+On-demand evaluation supports the same evaluators (built-in and custom) as online evaluation but provides precise control over which interactions to assess.
+
+## Prerequisites
+
+### Required Infrastructure
+
+- AWS account with IAM permissions
+- Amazon Bedrock access with model invocation permissions (for custom evaluators)
+- Amazon CloudWatch with **Transaction Search** enabled
+- ADOT (AWS Distro for OpenTelemetry) SDK instrumenting your agent
+
+### IAM User Permissions
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:CreateEvaluator",
+        "bedrock-agentcore:GetEvaluator",
+        "bedrock-agentcore:ListEvaluators",
+        "bedrock-agentcore:UpdateEvaluator",
+        "bedrock-agentcore:DeleteEvaluator",
+        "bedrock-agentcore:CreateOnlineEvaluationConfig",
+        "bedrock-agentcore:GetOnlineEvaluationConfig",
+        "bedrock-agentcore:ListOnlineEvaluationConfigs",
+        "bedrock-agentcore:UpdateOnlineEvaluationConfig",
+        "bedrock-agentcore:DeleteOnlineEvaluationConfig",
+        "bedrock-agentcore:Evaluate"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::*:role/AgentCoreEvaluationRole*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "bedrock-agentcore.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:Converse",
+        "bedrock:InvokeModelWithResponseStream",
+        "bedrock:ConverseStream"
+      ],
+      "Resource": [
+        "arn:aws:bedrock:*::foundation-model/*",
+        "arn:aws:bedrock:*:*:inference-profile/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeIndexPolicies",
+        "logs:PutIndexPolicy",
+        "logs:CreateLogGroup"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+### Service Execution Role
+
+AgentCore Evaluations requires an IAM execution role. Create it automatically (recommended) or manually:
+
+**Automatic** (AgentCore CLI):
+```bash
+# Role is created automatically during deploy
+agentcore deploy
+```
+
+**Automatic** (SDK):
+```python
+eval_client.create_online_config(
+    ...,
+    auto_create_execution_role=True  # Creates role automatically
+)
+```
+
+**Manual** — create a role with trust policy for `bedrock-agentcore.amazonaws.com` and permissions for CloudWatch read/write and Bedrock model invocation. See [Prerequisites (AWS Docs)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/evaluations-prerequisites.html) for the complete policy.
+
+## Limits
+
+| Limit | Value |
+|-------|-------|
+| Evaluation configurations per region per account | 1,000 |
+| Active configurations at any time | 100 |
+| Evaluators per configuration | 10 |
+| Input/output tokens per minute (large regions) | 1,000,000 |
+| Sampling percentage range | 0.01% – 100% |
+| Session idle timeout | 1 – 60 minutes (default: 15) |
+
+## Instrumentation Setup
+
+### Strands Agents
+
+Strands Agents includes built-in OpenTelemetry instrumentation. Configure the ADOT exporter:
+
+```python
+# Traces are automatically exported when OTEL is configured
+# Set environment variables:
+# OTEL_EXPORTER_OTLP_ENDPOINT=<your-collector-endpoint>
+# OTEL_RESOURCE_ATTRIBUTES=service.name=my_agent.DEFAULT
+```
+
+### LangGraph
+
+Use OpenInference instrumentation for LangGraph agents:
+
+```python
+# Configure OpenInference instrumentation
+# Traces are captured and exported to CloudWatch via ADOT
+```
+
+For agents hosted on AgentCore Runtime, follow the [Observability Service](../observability/README.md) setup guide.
+
+## Troubleshooting
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| No evaluation results | Traces not reaching CloudWatch | Verify ADOT instrumentation and log group configuration |
+| Custom evaluator locked | Used by active online evaluation | Pause the evaluation before modifying, or clone the evaluator |
+| Permission denied on create | Missing IAM actions | Add `bedrock-agentcore:CreateOnlineEvaluationConfig` and `iam:PassRole` |
+| Low sampling coverage | Sampling rate too low | Increase `samplingPercentage` in configuration |
+| Model invocation errors | Missing Bedrock permissions | Add `bedrock:InvokeModel` to execution role |
+
+## Related Services
+
+- **[Runtime Service](../runtime/README.md)**: Deploy agents that generate traces for evaluation
+- **[Observability Service](../observability/README.md)**: Configure trace collection and monitoring
+- **[Gateway Service](../gateway/README.md)**: Evaluate tool invocation accuracy for Gateway targets
+- **[Agent Registry](../registry/README.md)**: Discover and catalog evaluated agents
+
+## References
+
+- [AgentCore Evaluations Overview](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/evaluations.html)
+- [How It Works](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/how-it-works-evaluations.html)
+- [Built-in Evaluators](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/built-in-evaluators-overview.html)
+- [Custom Evaluators](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/custom-evaluators.html)
+- [Online Evaluation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/online-evaluations.html)
+- [On-demand Evaluation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/on-demand-evaluations.html)
+- [Prerequisites](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/evaluations-prerequisites.html)

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/evaluations/README.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/evaluations/README.md
@@ -14,7 +14,7 @@ AgentCore Evaluations integrates with agent frameworks (**Strands Agents**, **La
 
 Resources that define how agent output is assessed. Each evaluator has a unique ARN:
 
-- **Built-in**: `arn:aws:bedrock-agentcore:::evaluator/Builtin.Helpfulness` (public, all users)
+- **Built-in**: `arn:aws:bedrock-agentcore:::evaluator/Builtin.Helpfulness` (public, all users — empty region/account is intentional for AWS-managed evaluators)
 - **Custom**: `arn:aws:bedrock-agentcore:<region>:<account>:evaluator/<id>` (private, access-controlled)
 
 ### Evaluation Types
@@ -93,6 +93,8 @@ Continuously monitors deployed agents using live production traffic with configu
 3. **Monitoring and analysis** — aggregated scores in dashboards, quality trends, session investigation
 
 ### Create with AgentCore CLI
+
+> **Prerequisite**: Install the AgentCore CLI with `npm install -g @aws/agentcore`. See [Runtime Service](../runtime/README.md) for details.
 
 ```bash
 agentcore add online-eval \

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/registry/README.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/registry/README.md
@@ -1,0 +1,384 @@
+# Agent Registry Service
+
+> **Status**: Preview (launched April 9, 2026)
+
+## Overview
+
+AWS Agent Registry is a fully managed discovery service within Amazon Bedrock AgentCore. It provides a private, governed catalog for organizing, curating, and discovering AI agents, MCP servers, tools, agent skills, and custom resources across an organization.
+
+**Problem it solves**: As organizations scale AI agents and tools, resources become siloed across teams. Teams build MCP servers, deploy agents, and create specialized tools, but without a central catalog, duplication of effort occurs because builders cannot discover what already exists.
+
+## Regional Availability
+
+| Region | Code |
+|--------|------|
+| US East (N. Virginia) | `us-east-1` |
+| US West (Oregon) | `us-west-2` |
+| Europe (Ireland) | `eu-west-1` |
+| Asia Pacific (Tokyo) | `ap-northeast-1` |
+| Asia Pacific (Sydney) | `ap-southeast-2` |
+
+## Core Concepts
+
+### Registries
+
+Top-level catalogs in your AWS account. Each registry has its own:
+- Name and description
+- Authorization configuration (IAM or JWT) — **cannot be changed after creation**
+- Approval settings (auto-approve or manual review)
+- Set of registry records
+
+**Naming**: Must start alphanumeric. Valid characters: `a-z`, `A-Z`, `0-9`, `_`, `-`, `.`, `/`. Max 64 characters.
+
+Organize registries by resource type, environment stage (prod/QA/dev), team, or use a single org-wide registry.
+
+### Registry Records
+
+Metadata entries describing individual resources. Each record has:
+- **Name** (max 255 chars) and **description** (max 4,096 chars)
+- **Version** (semantic versioning recommended)
+- **Descriptor type** (`MCP`, `A2A`, `SKILL`, `CUSTOM`)
+- **Type-specific metadata** (protocol definitions, tool schemas, etc.)
+
+### Resource Types
+
+| Descriptor Type | Description | Validation |
+|-----------------|-------------|------------|
+| **`MCP`** | MCP server + tool definitions | Validated against MCP protocol schema (multiple schema versions supported) |
+| **`A2A`** | Agent cards per A2A protocol spec | Validated against A2A agent card schema (version `0.3`) |
+| **`SKILL`** | Reusable capabilities with markdown documentation | Optional structured definition (schema `0.1.0`) |
+| **`CUSTOM`** | Any JSON metadata for resources that don't fit standard types | No validation (free-form JSON) |
+
+### Record Lifecycle
+
+```
+Create → DRAFT → Submit → PENDING_APPROVAL → Approve → APPROVED
+                                │                         │
+                                │ Reject                  │ Edit (new DRAFT revision;
+                                ▼                         │ approved stays in search)
+                           REJECTED ── Approve (direct) ──┘
+                                │
+                                └── Edit → DRAFT
+
+Any status → DEPRECATED (terminal, irreversible)
+```
+
+- **Draft**: Initial state. Not visible in search.
+- **Pending Approval**: Submitted for review. Not visible in search.
+- **Approved**: Visible in search results. Editing creates a new DRAFT revision while the approved revision stays active.
+- **Rejected**: Curator can directly approve, or publisher can edit (creates new DRAFT) and resubmit.
+- **Deprecated**: Terminal state — cannot be undone or edited. Removed from search but visible via `GetRegistryRecord` and `ListRegistryRecords` for auditing.
+
+### Key Personas
+
+| Persona | Responsibilities |
+|---------|-----------------|
+| **Administrator** | Creates registries, configures auth/approval, manages IAM permissions |
+| **Publisher** | Creates records for their resources, submits for approval, configures sync |
+| **Curator/Approver** | Reviews pending records, approves/rejects/deprecates based on org standards |
+| **Consumer** | Searches for and discovers approved resources (human or agent) |
+
+## Key Capabilities
+
+### Hybrid Search
+
+Combines semantic (vector-based, natural language) search with keyword matching. Both run simultaneously on every query with results ranked by weighted combination.
+
+**Ranking**: Name has strongest keyword influence, followed by description and descriptor content (equal weight).
+
+**Metadata filters** constrain results using operators:
+- `$eq`, `$ne` — Equals / not equals
+- `$in` — In list
+- `$and`, `$or` — Logical combinators
+
+Filterable fields: `name`, `descriptorType`, `version`.
+
+### MCP-Native Access
+
+Each registry exposes an MCP-compatible endpoint (MCP spec 2025-11-25):
+
+```
+https://bedrock-agentcore.<region>.amazonaws.com/registry/<registryId>/mcp
+```
+
+The endpoint provides one tool: `search_registry_records` with parameters:
+- `searchQuery` (required) — Natural language or keyword query (1-256 chars)
+- `maxResults` (1-20, default 10) — Number of results to return
+- `filter` (optional) — Metadata filter object
+
+Any MCP-compatible client (Claude Code, Kiro, etc.) can connect directly.
+
+See [MCP Endpoint Guide](mcp-endpoint.md) for detailed configuration.
+
+### Governance and Curation
+
+Configurable approval workflow with auto-approval or manual curator review.
+
+See [Governance Workflows](governance-workflows.md) for details.
+
+### Record Synchronization
+
+Pull metadata from live external MCP servers or A2A agent endpoints via URL-based discovery. Supports OAuth and IAM credential providers for outbound authorization. Creates new revisions automatically when upstream changes.
+
+See [Sync Configuration](sync-configuration.md) for details.
+
+### EventBridge Notifications
+
+Events sent to default EventBridge bus (source: `aws.bedrock-agentcore`) when:
+- Records are submitted for approval (`detail-type: "Registry Record State changed to Pending Approval"`)
+- Registries finish provisioning (`detail-type: "Registry State transitions from Creating to Ready"`)
+
+Enables automated review pipelines via Lambda, SNS, SQS, or Step Functions.
+
+### CloudTrail Audit
+
+All control plane API calls are logged as management events in CloudTrail.
+
+## API Reference
+
+### Control Plane CLI (`bedrock-agentcore-control`)
+
+#### Registry Operations
+
+| Operation | CLI Command |
+|-----------|-------------|
+| Create registry | `aws bedrock-agentcore-control create-registry` |
+| Get registry | `aws bedrock-agentcore-control get-registry` |
+| Update registry | `aws bedrock-agentcore-control update-registry` |
+| Delete registry | `aws bedrock-agentcore-control delete-registry` |
+| List registries | `aws bedrock-agentcore-control list-registries` |
+
+#### Record Operations
+
+| Operation | CLI Command |
+|-----------|-------------|
+| Create record | `aws bedrock-agentcore-control create-registry-record` |
+| Get record | `aws bedrock-agentcore-control get-registry-record` |
+| Update record | `aws bedrock-agentcore-control update-registry-record` |
+| Delete record | `aws bedrock-agentcore-control delete-registry-record` |
+| List records | `aws bedrock-agentcore-control list-registry-records` |
+
+#### Approval Operations
+
+| Operation | CLI Command |
+|-----------|-------------|
+| Submit for approval | `aws bedrock-agentcore-control submit-registry-record-for-approval` |
+| Update status (approve/reject/deprecate) | `aws bedrock-agentcore-control update-registry-record-status` |
+
+### Data Plane CLI (`bedrock-agentcore`)
+
+| Operation | CLI Command |
+|-----------|-------------|
+| Search records | `aws bedrock-agentcore search-registry-records` |
+| MCP endpoint | POST to `https://bedrock-agentcore.<region>.amazonaws.com/registry/<registryId>/mcp` |
+
+### IAM Actions
+
+> **Important**: ALL IAM actions use the `bedrock-agentcore:` prefix — both control and data plane operations.
+
+**Control Plane:**
+
+| Action | Description |
+|--------|-------------|
+| `bedrock-agentcore:CreateRegistry` | Create a registry |
+| `bedrock-agentcore:GetRegistry` | Get a registry |
+| `bedrock-agentcore:UpdateRegistry` | Update a registry |
+| `bedrock-agentcore:DeleteRegistry` | Delete a registry |
+| `bedrock-agentcore:ListRegistries` | List registries |
+| `bedrock-agentcore:CreateRegistryRecord` | Create a record |
+| `bedrock-agentcore:GetRegistryRecord` | Get a record |
+| `bedrock-agentcore:UpdateRegistryRecord` | Update a record |
+| `bedrock-agentcore:DeleteRegistryRecord` | Delete a record |
+| `bedrock-agentcore:ListRegistryRecords` | List records |
+| `bedrock-agentcore:SubmitRegistryRecordForApproval` | Submit for approval |
+| `bedrock-agentcore:UpdateRegistryRecordStatus` | Approve/reject/deprecate |
+
+**Data Plane:**
+
+| Action | Description |
+|--------|-------------|
+| `bedrock-agentcore:SearchRegistryRecords` | Search registry records |
+| `bedrock-agentcore:InvokeRegistryMcp` | Invoke registry MCP endpoint |
+
+> **Note**: MCP tool invocation requires BOTH `InvokeRegistryMcp` AND `SearchRegistryRecords`.
+
+**Resource ARN Formats:**
+- Registry: `arn:aws:bedrock-agentcore:{region}:{account}:registry/{registryId}`
+- Record: `arn:aws:bedrock-agentcore:{region}:{account}:registry/{registryId}/record/{recordId}`
+
+## Common Operations
+
+### Create a Registry
+
+```bash
+aws bedrock-agentcore-control create-registry \
+  --name "MyOrgRegistry" \
+  --description "Central catalog for all AI agents and tools" \
+  --region us-east-1
+```
+
+### Register an MCP Server
+
+```bash
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id <REGISTRY_ID> \
+  --name "WeatherServer" \
+  --descriptor-type MCP \
+  --descriptors '{
+    "mcp": {
+      "server": {"schemaVersion": "2025-12-11", "inlineContent": "{\"name\": \"weather-server\", \"description\": \"Weather data service\", \"version\": \"1.0.0\"}"},
+      "tools": {"protocolVersion": "2024-11-05", "inlineContent": "{\"tools\": [{\"name\": \"get_forecast\", \"description\": \"Get weather forecast\", \"inputSchema\": {\"type\": \"object\", \"properties\": {\"city\": {\"type\": \"string\"}}}}]}"}
+    }
+  }' \
+  --record-version "1.0" \
+  --region us-east-1
+```
+
+### Register an Agent (A2A)
+
+```bash
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id <REGISTRY_ID> \
+  --name "CustomerSupportAgent" \
+  --descriptor-type A2A \
+  --descriptors '{
+    "a2a": {
+      "agentCard": {"schemaVersion": "0.3", "inlineContent": "{\"name\": \"customer-support\", \"description\": \"Handles customer inquiries\", \"version\": \"1.0.0\", \"protocolVersion\": \"0.3.0\", \"url\": \"https://api.example.com/a2a\", \"capabilities\": {}, \"defaultInputModes\": [\"text/plain\"], \"defaultOutputModes\": [\"text/plain\"], \"skills\": [{\"id\": \"order-lookup\", \"name\": \"Order Lookup\", \"description\": \"Look up order status\", \"tags\": [\"orders\"]}]}"}
+    }
+  }' \
+  --record-version "1.0" \
+  --region us-east-1
+```
+
+### Search Records
+
+```bash
+aws bedrock-agentcore search-registry-records \
+  --search-query "weather forecast" \
+  --registry-ids "<REGISTRY_ARN>" \
+  --region us-east-1
+```
+
+### Search with Filters
+
+```bash
+aws bedrock-agentcore search-registry-records \
+  --search-query "customer" \
+  --registry-ids "<REGISTRY_ARN>" \
+  --filter '{"$and": [{"descriptorType": {"$eq": "A2A"}}, {"version": {"$eq": "1.0"}}]}' \
+  --region us-east-1
+```
+
+### Delete a Record
+
+```bash
+aws bedrock-agentcore-control delete-registry-record \
+  --registry-id <REGISTRY_ID> \
+  --record-id <RECORD_ID> \
+  --region us-east-1
+```
+
+> **Note**: Delete all records before deleting a registry.
+
+## Authorization
+
+### IAM (SigV4)
+
+Default authentication method. Works automatically with AWS CLI and SDKs.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:SearchRegistryRecords",
+        "bedrock-agentcore:InvokeRegistryMcp"
+      ],
+      "Resource": "arn:aws:bedrock-agentcore:<region>:<account>:registry/<registryId>"
+    }
+  ]
+}
+```
+
+### JWT (OAuth 2.0)
+
+Supports Amazon Cognito, Okta, Azure AD, or any OIDC-compatible provider. Configure during registry creation. **Authorization type cannot be changed after creation.**
+
+```bash
+aws bedrock-agentcore-control create-registry \
+  --name "external-registry" \
+  --authorizer-type CUSTOM_JWT \
+  --authorizer-configuration '{
+    "customJWTAuthorizer": {
+      "discoveryUrl": "https://cognito-idp.us-east-1.amazonaws.com/<poolId>/.well-known/openid-configuration",
+      "allowedClients": ["<appClientId>"]
+    }
+  }' \
+  --region us-east-1
+```
+
+> **Constraint**: At least one JWT field required: `allowedAudiences`, `allowedClients`, `allowedScopes`, or `customClaims`. If multiple configured, ALL are verified.
+
+## Best Practices
+
+### Registry Organization
+- **Single org-wide registry** for small organizations with few teams
+- **Per-team registries** for larger organizations with clear ownership boundaries
+- **Per-environment registries** (dev/staging/prod) for strict deployment governance
+
+### Naming Conventions
+- Use descriptive, unique names (e.g., `payments-mcp-server-v2` not `server1`)
+- Include team/domain prefix when using shared registries (e.g., `platform/auth-agent`)
+- Use semantic versioning for record versions
+
+### Search Optimization
+- Write detailed descriptions to improve semantic search relevance
+- Use consistent descriptor types to enable effective filtering
+- Include relevant keywords in record metadata
+
+### Security
+- Use IAM for internal (AWS-to-AWS) access patterns
+- Use JWT for external or cross-organization access
+- Enable manual approval for production registries
+- Audit all registry operations via CloudTrail
+
+## Troubleshooting
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| Record not found in search | Record not approved | Check record status; submit for approval if in Draft |
+| MCP endpoint 403 | Missing IAM permissions | Add both `InvokeRegistryMcp` and `SearchRegistryRecords` |
+| Search returns no results | No approved records match query | Verify records exist and are approved; broaden search query |
+| Create registry fails | Region not supported | Use one of the 5 supported preview regions |
+| Schema validation error `'0.3.0' is not supported` | Wrong A2A schema version | Use `"schemaVersion": "0.3"` (not `0.3.0`) |
+| Sync not updating | Credential provider misconfigured | Verify outbound OAuth/IAM credentials for the source URL |
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Getting Started](getting-started.md) | End-to-end quick start walkthrough |
+| [MCP Endpoint Guide](mcp-endpoint.md) | Configure and use registry MCP endpoint with Claude Code |
+| [Governance Workflows](governance-workflows.md) | Approval lifecycle and EventBridge automation |
+| [Sync Configuration](sync-configuration.md) | URL-based sync from external MCP servers and A2A agents |
+| [Registry Integration Patterns](../../cross-service/registry-integration.md) | Cross-service patterns with Gateway, Identity, Runtime |
+
+## Related Services
+
+- **[Gateway Service](../gateway/README.md)**: Deploy discovered MCP servers as Gateway targets
+- **[Runtime Service](../runtime/README.md)**: Execute discovered agents in serverless runtime
+- **[Identity Service](../identity/README.md)**: Manage credentials for registry authorization
+- **[Observability Service](../observability/README.md)**: Monitor registry usage and search patterns
+
+## References
+
+- [AWS Agent Registry Documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/registry.html)
+- [Registry Concepts](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/registry-concepts.html)
+- [Supported Record Types](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/registry-supported-record-types.html)
+- [Registry Search](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/registry-search-records.html)
+- [Registry MCP Endpoint](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/registry-mcp-endpoint.html)
+- [IAM Permissions](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/registry-iam-permissions.html)
+- [Record Lifecycle](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/registry-record-lifecycle.html)
+- [Record Synchronization](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/registry-sync-records.html)

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/registry/getting-started.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/registry/getting-started.md
@@ -1,0 +1,307 @@
+# Agent Registry - Getting Started
+
+This guide walks through a complete workflow: creating a registry, registering resources, managing approvals, and searching.
+
+## Prerequisites
+
+- AWS CLI v2 configured with appropriate permissions
+- An AWS account in a [supported region](README.md#regional-availability)
+- Python 3.10+ and boto3 (for SDK examples)
+
+### Minimum IAM Policy (Administrator)
+
+> **Important**: ALL IAM actions use the `bedrock-agentcore:` prefix — both control and data plane.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "RegistryAndRecordManagement",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:CreateRegistry",
+        "bedrock-agentcore:GetRegistry",
+        "bedrock-agentcore:UpdateRegistry",
+        "bedrock-agentcore:DeleteRegistry",
+        "bedrock-agentcore:ListRegistries",
+        "bedrock-agentcore:CreateRegistryRecord",
+        "bedrock-agentcore:GetRegistryRecord",
+        "bedrock-agentcore:UpdateRegistryRecord",
+        "bedrock-agentcore:DeleteRegistryRecord",
+        "bedrock-agentcore:ListRegistryRecords",
+        "bedrock-agentcore:SubmitRegistryRecordForApproval",
+        "bedrock-agentcore:UpdateRegistryRecordStatus"
+      ],
+      "Resource": "arn:aws:bedrock-agentcore:*:<account>:*"
+    },
+    {
+      "Sid": "SearchAndMcp",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:SearchRegistryRecords",
+        "bedrock-agentcore:InvokeRegistryMcp"
+      ],
+      "Resource": "arn:aws:bedrock-agentcore:*:<account>:registry/*"
+    }
+  ]
+}
+```
+
+For per-persona IAM policies (Publisher, Curator, Consumer), see [Registry Prerequisites](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/registry-prerequisites.html).
+
+## Step 1: Create a Registry
+
+```bash
+aws bedrock-agentcore-control create-registry \
+  --name "my-org-registry" \
+  --description "Central catalog for AI agents and MCP servers" \
+  --region us-east-1
+```
+
+**Response** (key fields):
+```json
+{
+  "registryId": "reg-abc123def456",
+  "name": "my-org-registry",
+  "status": "CREATING"
+}
+```
+
+Wait for the registry to become `READY`:
+
+```bash
+aws bedrock-agentcore-control get-registry \
+  --registry-id reg-abc123def456 \
+  --region us-east-1 \
+  --query "status"
+```
+
+> **Note**: Authorization type (IAM or JWT) is set at creation and **cannot be changed** afterward.
+
+## Step 2: Register a Resource
+
+### Option A: Register an MCP Server
+
+MCP descriptors separate **server** metadata and **tools** definition, each with their own schema/protocol version:
+
+```bash
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id reg-abc123def456 \
+  --name "weather-mcp-server" \
+  --description "Provides real-time weather data and forecasts for global locations" \
+  --descriptor-type MCP \
+  --descriptors '{
+    "mcp": {
+      "server": {
+        "schemaVersion": "2025-12-11",
+        "inlineContent": "{\"name\": \"io.example/weather-server\", \"description\": \"Weather data and forecasts via OpenWeatherMap API\", \"version\": \"1.0.0\"}"
+      },
+      "tools": {
+        "protocolVersion": "2024-11-05",
+        "inlineContent": "{\"tools\": [{\"name\": \"get_forecast\", \"description\": \"Get 7-day weather forecast for a city\", \"inputSchema\": {\"type\": \"object\", \"properties\": {\"city\": {\"type\": \"string\", \"description\": \"City name\"}, \"units\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]}}, \"required\": [\"city\"]}}]}"
+      }
+    }
+  }' \
+  --record-version "1.0.0" \
+  --region us-east-1
+```
+
+**Supported server schemaVersions**: `2025-12-11`, `2025-10-17`, `2025-10-11`, `2025-09-29`, `2025-09-16`, `2025-07-09`
+**Supported tools protocolVersions**: `2025-11-25`, `2025-06-18`, `2025-03-26`, `2024-11-05`
+
+### Option B: Register an Agent (A2A)
+
+Agent cards follow the A2A protocol specification. Use schema version `0.3` (not `0.3.0`):
+
+```bash
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id reg-abc123def456 \
+  --name "customer-support-agent" \
+  --description "Handles customer inquiries, order status, and refund requests" \
+  --descriptor-type A2A \
+  --descriptors '{
+    "a2a": {
+      "agentCard": {
+        "schemaVersion": "0.3",
+        "inlineContent": "{\"name\": \"customer-support\", \"description\": \"Handles customer inquiries\", \"version\": \"1.0.0\", \"protocolVersion\": \"0.3.0\", \"url\": \"https://api.example.com/a2a\", \"capabilities\": {}, \"defaultInputModes\": [\"text/plain\"], \"defaultOutputModes\": [\"text/plain\"], \"skills\": [{\"id\": \"order-lookup\", \"name\": \"Order Lookup\", \"description\": \"Look up order status\", \"tags\": [\"orders\"]}]}"
+      }
+    }
+  }' \
+  --record-version "1.0.0" \
+  --region us-east-1
+```
+
+### Option C: Register a Skill
+
+Skill records support optional markdown documentation and a structured definition:
+
+```bash
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id reg-abc123def456 \
+  --name "data-analysis-skill" \
+  --description "Reusable skill for analyzing CSV/Parquet datasets with statistical summaries" \
+  --descriptor-type SKILL \
+  --descriptors '{
+    "agentSkills": {
+      "skillMarkdown": {
+        "inlineContent": "---\nname: data-analysis\ndescription: Analyzes tabular data files and produces statistical summaries.\n---\n# Data Analysis Skill\n\n## Inputs\n- File path (CSV or Parquet)\n- Analysis type: descriptive, correlation, or regression\n\n## Outputs\n- Summary statistics\n- Visualizations (PNG)\n- Markdown report"
+      },
+      "skillDefinition": {
+        "schemaVersion": "0.1.0",
+        "inlineContent": "{\"websiteUrl\": \"https://example.com/data-analysis\", \"repository\": {\"url\": \"https://github.com/example/data-analysis-skill\", \"source\": \"github\"}}"
+      }
+    }
+  }' \
+  --record-version "1.0.0" \
+  --region us-east-1
+```
+
+### Option D: Register a Custom Resource
+
+Custom records accept any valid JSON with no schema validation:
+
+```bash
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id reg-abc123def456 \
+  --name "product-knowledge-base" \
+  --description "Bedrock Knowledge Base with product catalog and documentation" \
+  --descriptor-type CUSTOM \
+  --descriptors '{
+    "custom": {
+      "metadata": {
+        "inlineContent": "{\"type\": \"knowledge-base\", \"knowledgeBaseId\": \"KB12345\", \"dataSourceCount\": 3, \"documentCount\": 15000, \"lastSyncedAt\": \"2026-04-01T00:00:00Z\"}"
+      }
+    }
+  }' \
+  --record-version "1.0.0" \
+  --region us-east-1
+```
+
+## Step 3: Submit for Approval
+
+Records start in **Draft** status. Submit to make them discoverable:
+
+```bash
+aws bedrock-agentcore-control submit-registry-record-for-approval \
+  --registry-id reg-abc123def456 \
+  --record-id rec-xyz789 \
+  --region us-east-1
+```
+
+The record moves to **Pending Approval** (or **Approved** if auto-approval is enabled).
+
+## Step 4: Approve (Curator Role)
+
+If the registry uses manual approval, a curator must review and approve:
+
+```bash
+# Approve
+aws bedrock-agentcore-control update-registry-record-status \
+  --registry-id reg-abc123def456 \
+  --record-id rec-xyz789 \
+  --status APPROVED \
+  --status-reason "Reviewed: description is clear, schema is valid, team ownership confirmed" \
+  --region us-east-1
+```
+
+```bash
+# Or reject with reason
+aws bedrock-agentcore-control update-registry-record-status \
+  --registry-id reg-abc123def456 \
+  --record-id rec-xyz789 \
+  --status REJECTED \
+  --status-reason "Missing tool descriptions - please add descriptions to all tools before resubmitting" \
+  --region us-east-1
+```
+
+> **Note**: Curators can directly approve a rejected record without requiring the publisher to resubmit.
+
+## Step 5: Search and Discover
+
+Once approved, records are searchable. **Eventual consistency**: approved records typically appear within seconds but may take up to minutes.
+
+### Semantic Search (Natural Language)
+
+```bash
+aws bedrock-agentcore search-registry-records \
+  --search-query "I need a tool that can tell me the weather" \
+  --registry-ids "arn:aws:bedrock-agentcore:us-east-1:<account-id>:registry/reg-abc123def456" \
+  --region us-east-1
+```
+
+### Filtered Search
+
+```bash
+# Find only MCP servers
+aws bedrock-agentcore search-registry-records \
+  --search-query "data processing" \
+  --registry-ids "arn:aws:bedrock-agentcore:us-east-1:<account-id>:registry/reg-abc123def456" \
+  --filter '{"descriptorType": {"$eq": "MCP"}}' \
+  --region us-east-1
+```
+
+```bash
+# Find A2A agents at version 1.0
+aws bedrock-agentcore search-registry-records \
+  --search-query "customer" \
+  --registry-ids "arn:aws:bedrock-agentcore:us-east-1:<account-id>:registry/reg-abc123def456" \
+  --filter '{"$and": [{"descriptorType": {"$eq": "A2A"}}, {"version": {"$eq": "1.0.0"}}]}' \
+  --region us-east-1
+```
+
+### Search via MCP Endpoint
+
+Any MCP-compatible client can search directly. See [MCP Endpoint Guide](mcp-endpoint.md) for Claude Code and Kiro integration.
+
+## Complete Example: Team Onboarding
+
+```bash
+REGION="us-east-1"
+REGISTRY_ID="reg-abc123def456"
+
+# 1. Team publishes their MCP server
+RECORD=$(aws bedrock-agentcore-control create-registry-record \
+  --registry-id $REGISTRY_ID \
+  --name "payments-mcp-server" \
+  --description "Payment processing tools: charge, refund, status lookup" \
+  --descriptor-type MCP \
+  --descriptors '{
+    "mcp": {
+      "server": {"schemaVersion": "2025-12-11", "inlineContent": "{\"name\": \"payments\", \"description\": \"Payment processing\", \"version\": \"2.1.0\"}"},
+      "tools": {"protocolVersion": "2024-11-05", "inlineContent": "{\"tools\": [{\"name\": \"charge\", \"description\": \"Process a payment\"}, {\"name\": \"refund\", \"description\": \"Issue a refund\"}, {\"name\": \"get_status\", \"description\": \"Check payment status\"}]}"}
+    }
+  }' \
+  --record-version "2.1.0" \
+  --region $REGION \
+  --query "recordId" --output text)
+
+echo "Created record: $RECORD"
+
+# 2. Submit for review
+aws bedrock-agentcore-control submit-registry-record-for-approval \
+  --registry-id $REGISTRY_ID \
+  --record-id $RECORD \
+  --region $REGION
+
+# 3. Curator approves
+aws bedrock-agentcore-control update-registry-record-status \
+  --registry-id $REGISTRY_ID \
+  --record-id $RECORD \
+  --status APPROVED \
+  --status-reason "Payment team tools approved - schema valid, descriptions clear" \
+  --region $REGION
+
+# 4. Other teams can now discover it
+aws bedrock-agentcore search-registry-records \
+  --search-query "payment processing" \
+  --registry-ids "arn:aws:bedrock-agentcore:${REGION}:$(aws sts get-caller-identity --query Account --output text):registry/${REGISTRY_ID}" \
+  --region $REGION
+```
+
+## Next Steps
+
+- [MCP Endpoint Guide](mcp-endpoint.md) — Connect Claude Code or Kiro to your registry
+- [Governance Workflows](governance-workflows.md) — Set up automated approval pipelines
+- [Sync Configuration](sync-configuration.md) — Auto-sync from live MCP servers and A2A agents
+- [Registry Integration Patterns](../../cross-service/registry-integration.md) — Combine with Gateway, Runtime, Identity

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/registry/governance-workflows.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/registry/governance-workflows.md
@@ -1,0 +1,326 @@
+# Agent Registry - Governance Workflows
+
+Agent Registry provides a governance layer with configurable approval workflows to ensure only reviewed, curated resources are discoverable across your organization.
+
+## Record Lifecycle
+
+```
+Create → DRAFT → Submit → PENDING_APPROVAL → Approve → APPROVED
+                                │                         │
+                                │ Reject                  │ Edit (new DRAFT revision;
+                                ▼                         │ approved stays in search)
+                           REJECTED ── Approve (direct) ──┘
+                                │
+                                └── Edit → DRAFT
+
+Any status → DEPRECATED (terminal, irreversible)
+```
+
+### Status Details
+
+| Status | Visible in Search | Can Edit | Can Submit | Notes |
+|--------|-------------------|----------|------------|-------|
+| **Draft** | No | Yes (in place) | Yes | Initial state after create |
+| **Pending Approval** | No | Yes (creates new DRAFT; pending revision discarded) | No | Awaiting curator review |
+| **Approved** | **Yes** | Yes (creates new DRAFT; approved stays active) | No | Discoverable by consumers |
+| **Rejected** | No | Yes (creates new DRAFT) | Via new DRAFT | Curator can directly approve |
+| **Deprecated** | No | **No** | **No** | Terminal — irreversible |
+
+### Dual-Revision Behavior
+
+When editing an **Approved** record, the system creates a new DRAFT revision while the approved revision **remains visible in search**. The new DRAFT must go through the normal submit-and-approve flow. This ensures consumers always have access to the last approved version during updates.
+
+### Visibility Rules
+
+| API | What It Returns |
+|-----|-----------------|
+| `SearchRegistryRecords` | Only approved revisions |
+| `InvokeRegistryMcp` | Only approved revisions |
+| `GetRegistryRecord` | Latest revision (any status) |
+| `ListRegistryRecords` | Latest revision (any status) |
+
+## Approval Modes
+
+### Auto-Approval
+
+Records are automatically approved upon submission. Suitable for development environments or trusted teams.
+
+```bash
+aws bedrock-agentcore-control create-registry \
+  --name "dev-registry" \
+  --description "Development registry with auto-approval" \
+  --region us-east-1
+```
+
+> **Note**: Switching auto-approval from OFF to ON only affects records submitted after the change. Existing `PENDING_APPROVAL` records must still be manually approved or rejected.
+
+### Manual Approval (Default)
+
+Records require curator review. Suitable for production registries and organization-wide catalogs.
+
+## Curator Workflows
+
+### Review Pending Records
+
+```bash
+# List all records (filter output for pending status)
+aws bedrock-agentcore-control list-registry-records \
+  --registry-id <REGISTRY_ID> \
+  --region us-east-1
+```
+
+```bash
+# Get full details of a pending record
+aws bedrock-agentcore-control get-registry-record \
+  --registry-id <REGISTRY_ID> \
+  --record-id <RECORD_ID> \
+  --region us-east-1
+```
+
+### Approve a Record
+
+```bash
+aws bedrock-agentcore-control update-registry-record-status \
+  --registry-id <REGISTRY_ID> \
+  --record-id <RECORD_ID> \
+  --status APPROVED \
+  --status-reason "Schema validated, tool descriptions are clear, team ownership confirmed" \
+  --region us-east-1
+```
+
+> **Note**: Curators can directly approve a **Rejected** record without the publisher needing to resubmit.
+
+### Reject a Record
+
+```bash
+aws bedrock-agentcore-control update-registry-record-status \
+  --registry-id <REGISTRY_ID> \
+  --record-id <RECORD_ID> \
+  --status REJECTED \
+  --status-reason "Tool descriptions are too vague - please add input/output examples" \
+  --region us-east-1
+```
+
+### Deprecate a Record
+
+Deprecation is available from **any status** and is a **terminal, irreversible** operation. The record cannot be edited or un-deprecated. It remains visible via `GetRegistryRecord` and `ListRegistryRecords` for auditing but is removed from search.
+
+```bash
+aws bedrock-agentcore-control update-registry-record-status \
+  --registry-id <REGISTRY_ID> \
+  --record-id <RECORD_ID> \
+  --status DEPRECATED \
+  --status-reason "Replaced by payments-mcp-server-v3 (rec-newid). Migrate by 2026-06-01." \
+  --region us-east-1
+```
+
+## EventBridge Automation
+
+Agent Registry emits events to the default EventBridge bus (source: `aws.bedrock-agentcore`).
+
+### Event Types
+
+| Detail Type | Trigger |
+|-------------|---------|
+| `Registry Record State changed to Pending Approval` | `submit-registry-record-for-approval` called |
+| `Registry State transitions from Creating to Ready` | Registry provisioning completes |
+
+### Event Schema
+
+```json
+{
+  "version": "0",
+  "detail-type": "Registry Record State changed to Pending Approval",
+  "source": "aws.bedrock-agentcore",
+  "account": "<account-id>",
+  "region": "us-west-2",
+  "resources": [
+    "arn:aws:bedrock-agentcore:us-west-2:<account-id>:registry/REG_ID/record/REC_ID"
+  ],
+  "detail": {
+    "registryRecordId": "REC_ID",
+    "registryId": "REG_ID"
+  }
+}
+```
+
+### Pattern 1: Slack Notification on Submission
+
+```json
+{
+  "source": ["aws.bedrock-agentcore"],
+  "detail-type": ["Registry Record State changed to Pending Approval"],
+  "detail": {
+    "registryId": ["reg-abc123def456"]
+  }
+}
+```
+
+**Lambda Handler** (Python):
+```python
+import json
+import urllib3
+import boto3
+
+SLACK_WEBHOOK_URL = "https://hooks.slack.com/services/T.../B.../xxx"
+client = boto3.client("bedrock-agentcore-control")
+
+def handler(event, context):
+    detail = event["detail"]
+    registry_id = detail["registryId"]
+    record_id = detail["registryRecordId"]
+
+    # Fetch record details for the notification
+    record = client.get_registry_record(
+        registryId=registry_id,
+        recordId=record_id
+    )
+
+    message = {
+        "text": f":clipboard: New registry record pending approval\n"
+                f"*Record*: {record['name']}\n"
+                f"*Type*: {record['descriptorType']}\n"
+                f"*Registry*: {registry_id}\n"
+                f"*Record ID*: {record_id}"
+    }
+    http = urllib3.PoolManager()
+    http.request("POST", SLACK_WEBHOOK_URL,
+                 body=json.dumps(message),
+                 headers={"Content-Type": "application/json"})
+```
+
+### Pattern 2: Automated Schema Validation
+
+Automatically validate MCP server schemas before curator review.
+
+**EventBridge Rule** (target: Lambda):
+```json
+{
+  "source": ["aws.bedrock-agentcore"],
+  "detail-type": ["Registry Record State changed to Pending Approval"]
+}
+```
+
+**Lambda Handler** (Python):
+```python
+import json
+import boto3
+
+client = boto3.client("bedrock-agentcore-control")
+
+def handler(event, context):
+    detail = event["detail"]
+    registry_id = detail["registryId"]
+    record_id = detail["registryRecordId"]
+
+    # Get the full record
+    record = client.get_registry_record(
+        registryId=registry_id,
+        recordId=record_id
+    )
+
+    # Only auto-validate MCP records
+    if record.get("descriptorType") != "MCP":
+        return  # Leave non-MCP records for manual review
+
+    # Validate MCP schema has required fields
+    descriptors = record.get("descriptors", {})
+    mcp = descriptors.get("mcp", {})
+    tools_content = mcp.get("tools", {}).get("inlineContent", "{}")
+    tools_data = json.loads(tools_content)
+
+    issues = []
+    tools = tools_data.get("tools", [])
+    if not tools:
+        issues.append("No tools defined in MCP server schema")
+
+    for tool in tools:
+        if not tool.get("description"):
+            issues.append(f"Tool '{tool.get('name', 'unnamed')}' missing description")
+        if not tool.get("inputSchema"):
+            issues.append(f"Tool '{tool.get('name', 'unnamed')}' missing inputSchema")
+
+    if issues:
+        client.update_registry_record_status(
+            registryId=registry_id,
+            recordId=record_id,
+            status="REJECTED",
+            statusReason=f"Auto-validation failed: {'; '.join(issues)}"
+        )
+    else:
+        client.update_registry_record_status(
+            registryId=registry_id,
+            recordId=record_id,
+            status="APPROVED",
+            statusReason="Auto-validated: all tools have descriptions and input schemas"
+        )
+```
+
+### Pattern 3: Step Functions Review Pipeline
+
+For complex multi-step review processes:
+
+```
+┌──────────────┐     ┌───────────────┐     ┌──────────────┐
+│ EventBridge  │ ──> │ Step Function │ ──> │ Auto-validate│
+│ (submission) │     │ (orchestrate) │     │ (Lambda)     │
+└──────────────┘     └───────────────┘     └──────┬───────┘
+                                                   │
+                                          ┌────────┴────────┐
+                                          │                 │
+                                     Pass ▼            Fail ▼
+                              ┌──────────────┐   ┌──────────────┐
+                              │ Notify Slack │   │ Reject with  │
+                              │ for human    │   │ feedback     │
+                              │ review       │   └──────────────┘
+                              └──────────────┘
+```
+
+## Governance Best Practices
+
+### For Administrators
+- Use **manual approval** for production registries
+- Use **auto-approval** only for dev/sandbox environments
+- Set up EventBridge rules for all submission events
+- Assign dedicated curator IAM roles per registry (use `bedrock-agentcore:UpdateRegistryRecordStatus` scoped to specific registry ARN)
+
+### For Publishers
+- Write detailed, searchable descriptions
+- Include all tool descriptions and input schemas for MCP servers
+- Use semantic versioning for record versions
+- Include migration notes when deprecating records
+
+### For Curators
+- Always provide actionable `statusReason` when rejecting
+- Verify schema completeness (tools have descriptions, inputs documented)
+- Check for duplicate resources before approving
+- **Deprecate** rather than delete when replacing records (preserves audit trail)
+- Use **direct approve** for rejected records when the publisher has fixed issues out-of-band
+
+### Review Checklist
+
+Before approving a record, verify:
+
+- [ ] **Description** is clear and searchable (max 4,096 chars)
+- [ ] **Version** follows semantic versioning
+- [ ] **Schema** (for MCP/A2A types) is valid and complete
+- [ ] **Tool descriptions** are specific enough for AI agents to understand
+- [ ] **No duplicates** of existing approved records
+- [ ] **Team ownership** is identifiable from the record name/description
+
+## CloudTrail Audit
+
+All approval actions are logged in CloudTrail:
+
+```bash
+aws cloudtrail lookup-events \
+  --lookup-attributes AttributeKey=EventName,AttributeValue=UpdateRegistryRecordStatus \
+  --region us-east-1
+```
+
+## Related
+
+- [Registry Overview](README.md)
+- [Getting Started](getting-started.md)
+- [Record Lifecycle (AWS Docs)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/registry-record-lifecycle.html)
+- [EventBridge Notifications (AWS Docs)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/registry-eventbridge.html)

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/registry/governance-workflows.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/registry/governance-workflows.md
@@ -49,6 +49,7 @@ Records are automatically approved upon submission. Suitable for development env
 aws bedrock-agentcore-control create-registry \
   --name "dev-registry" \
   --description "Development registry with auto-approval" \
+  --approval-configuration '{"autoApproval": true}' \
   --region us-east-1
 ```
 

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/registry/mcp-endpoint.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/registry/mcp-endpoint.md
@@ -1,0 +1,304 @@
+# Agent Registry - MCP Endpoint
+
+Each Agent Registry exposes an MCP-compatible endpoint (MCP spec 2025-11-25) that any MCP client can connect to for searching registry records. This enables AI coding assistants (Claude Code, Kiro) and agents to discover available tools, agents, and resources through their native MCP integration.
+
+## Endpoint Format
+
+```
+https://bedrock-agentcore.<region>.amazonaws.com/registry/<registryId>/mcp
+```
+
+The endpoint exposes a single MCP tool: `search_registry_records`.
+
+### Tool Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `searchQuery` | string | Yes | Natural language or keyword query (1-256 chars) |
+| `maxResults` | integer | No | Number of results (1-20, default 10) |
+| `filter` | object | No | Metadata filter using `$eq`, `$ne`, `$in`, `$and`, `$or` operators |
+
+## IAM-Based Access (Recommended)
+
+### Using `mcp-proxy-for-aws`
+
+For IAM (SigV4) authentication, use the `mcp-proxy-for-aws` proxy which handles AWS signature signing automatically:
+
+```json
+{
+  "mcpServers": {
+    "agent-registry": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "mcp-proxy-for-aws@latest",
+        "https://bedrock-agentcore.<region>.amazonaws.com/registry/<registryId>/mcp",
+        "--service", "bedrock-agentcore",
+        "--region", "<region>",
+        "--profile", "my-profile"
+      ]
+    }
+  }
+}
+```
+
+Add this to `~/.claude/settings.json` (Claude Code) or your project's `.claude/settings.json`.
+
+### Required IAM Permissions
+
+MCP tool invocation requires **both** permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:InvokeRegistryMcp",
+        "bedrock-agentcore:SearchRegistryRecords"
+      ],
+      "Resource": "arn:aws:bedrock-agentcore:<region>:<account>:registry/<registryId>"
+    }
+  ]
+}
+```
+
+### Using via AWS CLI in Skill Context
+
+The `aws-agentic-ai` skill permits `Bash(aws bedrock-agentcore *)` for data plane commands. Search directly without MCP configuration:
+
+```bash
+aws bedrock-agentcore search-registry-records \
+  --search-query "your search query" \
+  --registry-ids "arn:aws:bedrock-agentcore:us-east-1:<account-id>:registry/reg-abc123def456" \
+  --region us-east-1
+```
+
+This approach works out of the box with existing AWS credential chains.
+
+## JWT-Based Access (OAuth 2.0)
+
+For external access or cross-organization scenarios. The registry must be created with `--authorizer-type CUSTOM_JWT`. **Authorization type cannot be changed after creation.**
+
+### Option 1: Bearer Token
+
+```json
+{
+  "mcpServers": {
+    "my-registry": {
+      "type": "http",
+      "url": "https://bedrock-agentcore.<region>.amazonaws.com/registry/<registryId>/mcp",
+      "headers": {
+        "Authorization": "Bearer ${ACCESS_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+### Option 2: Pre-Registered Client
+
+Register the client ID in the registry's authorizer configuration:
+
+```bash
+aws bedrock-agentcore-control update-registry \
+  --registry-id <registryId> \
+  --authorizer-configuration '{
+    "optionalValue": {
+      "customJWTAuthorizer": {
+        "discoveryUrl": "https://<idp-domain>/.well-known/openid-configuration",
+        "allowedClients": ["<client-id>"]
+      }
+    }
+  }' \
+  --region us-east-1
+```
+
+MCP client config:
+```json
+{
+  "mcpServers": {
+    "pre-registered-registry": {
+      "type": "http",
+      "url": "https://bedrock-agentcore.<region>.amazonaws.com/registry/<registryId>/mcp",
+      "oauth": {
+        "clientId": "<client-id>",
+        "callbackPort": "<port-number>"
+      }
+    }
+  }
+}
+```
+
+### Option 3: Dynamic Client Registration
+
+Configure with `allowedAudience` instead of `allowedClients`:
+
+```bash
+aws bedrock-agentcore-control update-registry \
+  --registry-id <registryId> \
+  --authorizer-configuration '{
+    "optionalValue": {
+      "customJWTAuthorizer": {
+        "discoveryUrl": "https://<idp-domain>/.well-known/openid-configuration",
+        "allowedAudience": ["https://bedrock-agentcore.<region>.amazonaws.com/registry/<registryId>/mcp"]
+      }
+    }
+  }' \
+  --region us-east-1
+```
+
+MCP client config (no `oauth` needed — uses DCR):
+```json
+{
+  "mcpServers": {
+    "dcr-registry": {
+      "type": "http",
+      "url": "https://bedrock-agentcore.<region>.amazonaws.com/registry/<registryId>/mcp"
+    }
+  }
+}
+```
+
+**OAuth well-known path** for resource metadata discovery:
+```
+https://bedrock-agentcore.<region>.amazonaws.com/.well-known/oauth-protected-resource/registry/<registryId>/mcp
+```
+
+Supported identity providers: Amazon Cognito, Okta, Azure AD (Microsoft Entra ID), Auth0, or any OIDC-compatible provider.
+
+## Kiro Integration
+
+Kiro supports MCP servers natively. Use the same `mcp-proxy-for-aws` approach for IAM:
+
+```json
+{
+  "mcpServers": {
+    "org-registry": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "mcp-proxy-for-aws@latest",
+        "https://bedrock-agentcore.<region>.amazonaws.com/registry/<registryId>/mcp",
+        "--service", "bedrock-agentcore",
+        "--region", "<region>"
+      ]
+    }
+  }
+}
+```
+
+## Search Examples via MCP
+
+### Basic Search
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "search_registry_records",
+    "arguments": {
+      "searchQuery": "payment processing tools"
+    }
+  },
+  "id": 1
+}
+```
+
+### Filtered Search (MCP Servers Only)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "search_registry_records",
+    "arguments": {
+      "searchQuery": "data analytics",
+      "maxResults": 5,
+      "filter": {
+        "descriptorType": {
+          "$eq": "MCP"
+        }
+      }
+    }
+  },
+  "id": 1
+}
+```
+
+### Complex Filter
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "search_registry_records",
+    "arguments": {
+      "searchQuery": "customer",
+      "filter": {
+        "$and": [
+          {"descriptorType": {"$in": ["A2A", "MCP"]}},
+          {"name": {"$ne": "deprecated-agent"}}
+        ]
+      }
+    }
+  },
+  "id": 1
+}
+```
+
+## Verification
+
+### IAM Verification
+
+```bash
+curl -s -X POST \
+  "https://bedrock-agentcore.<region>.amazonaws.com/registry/<registryId>/mcp" \
+  -H "Content-Type: application/json" \
+  -H "X-Amz-Security-Token: ${AWS_SESSION_TOKEN}" \
+  --aws-sigv4 "aws:amz:<region>:bedrock-agentcore" \
+  --user "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_registry_records","arguments":{"searchQuery":"weather"}}}'
+```
+
+### OAuth Verification
+
+```bash
+curl -s -X POST \
+  "https://bedrock-agentcore.<region>.amazonaws.com/registry/<registryId>/mcp" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"search_registry_records","arguments":{"searchQuery":"weather"}}}'
+```
+
+## Agent-to-Agent Discovery Pattern
+
+An AI agent can use the MCP endpoint to dynamically discover and invoke other agents:
+
+1. **Discover**: Agent searches registry for agents with specific capabilities
+2. **Evaluate**: Agent reads the A2A agent card to understand capabilities and endpoints
+3. **Invoke**: Agent calls the discovered agent via its advertised URL
+
+This enables dynamic, runtime agent composition without hardcoded dependencies.
+
+## Troubleshooting
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| 403 Forbidden | Missing IAM permission | Add both `InvokeRegistryMcp` and `SearchRegistryRecords` to role |
+| Connection refused | Wrong region or registry ID | Verify endpoint URL matches registry region and ID |
+| Empty results | No approved records | Ensure records are approved, not just in Draft status |
+| JWT auth fails | Token expired or wrong audience | Check token validity and `allowedClients`/`allowedAudience` config |
+| Timeout | Network/VPC configuration | Ensure outbound HTTPS (443) to `bedrock-agentcore.<region>.amazonaws.com` |
+| `mcp-proxy-for-aws` errors | Missing AWS credentials | Ensure `--profile` or environment variables are configured |
+
+## Related
+
+- [Registry Overview](README.md)
+- [Getting Started](getting-started.md)
+- [Governance Workflows](governance-workflows.md)
+- [AWS Registry MCP Endpoint Docs](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/registry-mcp-endpoint.html)

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/registry/sync-configuration.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/registry/sync-configuration.md
@@ -1,0 +1,258 @@
+# Agent Registry - Sync Configuration
+
+Agent Registry can automatically sync metadata from live external MCP servers and A2A agent endpoints via URL-based discovery. When the upstream source changes, the registry creates new record revisions automatically.
+
+## How Sync Works
+
+```
+┌──────────────────┐         ┌──────────────┐         ┌──────────────┐
+│ External MCP     │  pull   │ Agent        │  store   │ Registry     │
+│ Server / A2A     │ <────── │ Registry     │ ──────>  │ Record       │
+│ Agent (source)   │         │ Sync Engine  │         │ (new revision)│
+└──────────────────┘         └──────────────┘         └──────────────┘
+```
+
+1. Registry connects to the source URL using outbound credentials
+2. Retrieves server/tool definitions (MCP) or agent card (A2A)
+3. Populates/updates record descriptors, name, description, and version from source
+4. Creates a new revision if changes are detected
+
+> **Limitation**: SSE streaming from MCP servers is not supported at public preview launch.
+
+## Sync API Structure
+
+Sync uses dedicated parameters on `create-registry-record`, separate from `--descriptors`:
+
+```bash
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id <REGISTRY_ID> \
+  --name "<record-name>" \
+  --descriptor-type <MCP|A2A> \
+  --synchronization-type URL \
+  --synchronization-configuration '{"fromUrl": {"url": "<source-url>", ...}}' \
+  --region us-east-1
+```
+
+Key difference from inline records: use `--synchronization-type URL` and `--synchronization-configuration` instead of `--descriptors`.
+
+## Syncing MCP Servers
+
+### From a Public MCP Server (No Auth)
+
+```bash
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id <REGISTRY_ID> \
+  --name "aws-knowledge-server" \
+  --descriptor-type MCP \
+  --synchronization-type URL \
+  --synchronization-configuration '{
+    "fromUrl": {
+      "url": "https://knowledge-mcp.global.api.aws"
+    }
+  }' \
+  --region us-east-1
+```
+
+### From an OAuth-Protected MCP Server
+
+```bash
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id <REGISTRY_ID> \
+  --name "oauth-mcp-server" \
+  --descriptor-type MCP \
+  --synchronization-type URL \
+  --synchronization-configuration '{
+    "fromUrl": {
+      "url": "https://analytics.internal.example.com/mcp",
+      "credentialProviderConfigurations": [{
+        "credentialProviderType": "OAUTH",
+        "credentialProvider": {
+          "oauthCredentialProvider": {
+            "providerArn": "<OAUTH_PROVIDER_ARN>",
+            "grantType": "CLIENT_CREDENTIALS"
+          }
+        }
+      }]
+    }
+  }' \
+  --region us-east-1
+```
+
+**Additional IAM permissions for OAuth sync:**
+```json
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "bedrock-agentcore:GetWorkloadAccessToken",
+      "Resource": "arn:aws:bedrock-agentcore:*:<account>:workload-identity-directory/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "bedrock-agentcore:GetResourceOauth2Token",
+      "Resource": "arn:aws:bedrock-agentcore:*:<account>:token-vault/*"
+    }
+  ]
+}
+```
+
+### From an IAM-Protected MCP Server
+
+For MCP servers on AWS infrastructure (Gateway targets, Lambda, API Gateway) using SigV4:
+
+```bash
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id <REGISTRY_ID> \
+  --name "gateway-mcp-server" \
+  --descriptor-type MCP \
+  --synchronization-type URL \
+  --synchronization-configuration '{
+    "fromUrl": {
+      "url": "https://bedrock-agentcore.us-east-1.amazonaws.com/gateway/<gw-id>/target/<tgt-id>/mcp",
+      "credentialProviderConfigurations": [{
+        "credentialProviderType": "IAM",
+        "credentialProvider": {
+          "iamCredentialProvider": {
+            "roleArn": "arn:aws:iam::<account-id>:role/RegistrySyncRole",
+            "service": "bedrock-agentcore",
+            "region": "us-east-1"
+          }
+        }
+      }]
+    }
+  }' \
+  --region us-east-1
+```
+
+**`service` values for SigV4 signing:**
+- `bedrock-agentcore` — AgentCore Runtime/Gateway
+- `execute-api` — API Gateway
+- `lambda` — Lambda function URLs
+
+**`region`** is optional and defaults to the registry's region.
+
+**Additional IAM permissions for IAM-based sync:**
+```json
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::<account>:role/RegistrySyncRole",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "bedrock-agentcore.amazonaws.com"
+        },
+        "StringLike": {
+          "iam:AssociatedResourceARN": "arn:aws:bedrock-agentcore:<region>:<account>:registry/*/record/*"
+        }
+      }
+    }
+  ]
+}
+```
+
+The IAM role needs a trust policy:
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "bedrock-agentcore.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
+
+## Syncing A2A Agent Cards
+
+Sync agent cards from the standard A2A well-known endpoint:
+
+```bash
+aws bedrock-agentcore-control create-registry-record \
+  --registry-id <REGISTRY_ID> \
+  --name "travel-agent" \
+  --descriptor-type A2A \
+  --synchronization-type URL \
+  --synchronization-configuration '{
+    "fromUrl": {
+      "url": "https://agent.example.com/.well-known/agent-card.json"
+    }
+  }' \
+  --region us-east-1
+```
+
+For OAuth or IAM-protected agent endpoints, add `credentialProviderConfigurations` as shown in the MCP examples above.
+
+## Manually Triggering Sync
+
+To force a re-sync of an existing record:
+
+```bash
+aws bedrock-agentcore-control update-registry-record \
+  --registry-id <REGISTRY_ID> \
+  --record-id <RECORD_ID> \
+  --trigger-synchronization \
+  --region us-east-1
+```
+
+## Monitoring Sync Status
+
+```bash
+aws bedrock-agentcore-control get-registry-record \
+  --registry-id <REGISTRY_ID> \
+  --record-id <RECORD_ID> \
+  --region us-east-1
+```
+
+Check the `status` field. If sync fails, the record transitions to `CREATE_FAILED` or `UPDATE_FAILED`.
+
+## Sync vs Inline Content
+
+| Aspect | URL-based Sync | Inline Content |
+|--------|---------------|----------------|
+| **Source of truth** | External MCP server / A2A agent | Registry record itself |
+| **Updates** | Automatic on upstream changes | Manual via `update-registry-record` |
+| **Auth required** | Yes (if source is protected) | No |
+| **Descriptor types** | `MCP` and `A2A` only | All types (`MCP`, `A2A`, `SKILL`, `CUSTOM`) |
+| **Use case** | Live, evolving servers/agents | Stable, versioned resources |
+| **Network dependency** | Source must be publicly reachable (no private IPs) | None |
+
+### When to Use Sync
+
+- MCP servers that are actively developed and frequently updated
+- Gateway targets where tool definitions evolve with the upstream API
+- A2A agents that publish well-known agent cards
+- Multi-team environments where publishers manage their own servers
+
+### When to Use Inline Content
+
+- Stable, versioned resources that rarely change
+- Resources where the registry should be the sole source of truth
+- Skills and custom resources (sync not supported for `SKILL`/`CUSTOM` types)
+- Air-gapped environments or private network resources
+
+## Troubleshooting
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| `CREATE_FAILED` | Source URL unreachable | Verify URL resolves to a public IP; check DNS |
+| `CREATE_FAILED` | Credential provider misconfigured | Check OAuth client ID/secret or IAM role trust policy |
+| `UPDATE_FAILED` | HTTP non-200/202 response | Check source server health; verify credentials haven't expired |
+| `CREATE_FAILED` | URL resolves to private IP | Only public IPs are supported for sync |
+| `CREATE_FAILED` | MCP tools/list timeout | Source must respond within 30 seconds |
+| `CREATE_FAILED` | Response exceeds max size | Reduce the number of tools or simplify descriptions |
+| Record in Draft after sync | Sync populates content but doesn't auto-approve | Submit for approval after initial sync |
+
+## Related
+
+- [Registry Overview](README.md)
+- [Getting Started](getting-started.md)
+- [Cross-Service Credential Management](../../cross-service/credential-management.md)
+- [Record Synchronization (AWS Docs)](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/registry-sync-records.html)
+- [Gateway Service](../gateway/README.md) — Source of Gateway-based MCP targets
+- [Identity Service](../identity/README.md) — Credential providers for outbound auth

--- a/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/runtime/README.md
+++ b/plugins/aws-agentic-ai/skills/aws-agentic-ai/services/runtime/README.md
@@ -67,6 +67,92 @@ aws bedrock-agentcore-runtime invoke-agent-runtime \
   --region us-west-2
 ```
 
+## Transforming an Existing Agent
+
+To deploy an existing agent (built with Strands, LangGraph, or another framework) to AgentCore Runtime, wrap it with the `BedrockAgentCoreApp`:
+
+### Transformation Checklist
+
+1. **Add runtime dependency** to `requirements.txt`:
+   ```
+   bedrock-agentcore
+   strands-agents       # or your framework
+   ```
+
+2. **Add runtime import**:
+   ```python
+   from bedrock_agentcore.runtime import BedrockAgentCoreApp
+   ```
+
+3. **Initialize the application**:
+   ```python
+   app = BedrockAgentCoreApp()
+   ```
+
+4. **Decorate the main entrypoint** with `@app.entrypoint`:
+   ```python
+   @app.entrypoint
+   def handler(event, context):
+       # Your existing agent logic here
+       return agent.invoke(event)
+   ```
+
+5. **Add the application runner**:
+   ```python
+   if __name__ == "__main__":
+       app.run()
+   ```
+
+### Complete Transformation Example
+
+**Before** (standalone Strands agent):
+```python
+from strands import Agent
+
+agent = Agent(system_prompt="You are a helpful assistant.")
+response = agent("Hello!")
+```
+
+**After** (Runtime-compatible):
+```python
+from strands import Agent
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+
+app = BedrockAgentCoreApp()
+agent = Agent(system_prompt="You are a helpful assistant.")
+
+@app.entrypoint
+def handler(event, context):
+    user_input = event.get("input", "")
+    return agent(user_input)
+
+if __name__ == "__main__":
+    app.run()
+```
+
+### `@app.entrypoint` vs `@app.handler()`
+
+Both decorators register the main request handler. Use `@app.entrypoint` for simple synchronous handlers and `@app.handler()` for async handlers with streaming support:
+
+| Decorator | Use Case |
+|-----------|----------|
+| `@app.entrypoint` | Synchronous, request-response agents |
+| `@app.handler()` | Async agents, streaming, long-running tasks |
+
+### Alternative: AgentCore CLI Deployment
+
+The AgentCore CLI provides a streamlined deployment experience:
+
+```bash
+# Install the CLI
+npm install -g @aws/agentcore
+
+# Deploy (builds container, pushes to ECR, creates runtime)
+agentcore deploy
+```
+
+The CLI automates containerization, ECR push, and runtime creation. For manual control, use the AWS CLI workflow below.
+
 ## Core Concepts
 
 ### Runtime → Version → Endpoint
@@ -163,6 +249,7 @@ For production deployment architecture, detailed internals, and advanced pattern
 - **[Memory Service](../memory/README.md)**: Short-term (multi-turn) + long-term (cross-session) conversation memory
 - **[Identity Service](../identity/README.md)**: Credential providers, Token Vault, OAuth lifecycle management
 - **[Observability Service](../observability/README.md)**: OpenTelemetry tracing, CloudWatch metrics, X-Ray integration
+- **[Agent Registry](../registry/README.md)**: Catalog, discover, and govern deployed agents and tools
 
 ## References
 


### PR DESCRIPTION
## Summary

Expand the `aws-agentic-ai` plugin with new AgentCore services, a bundled MCP server, and cross-service best-practice guides:

- **Agent Registry** (6 files): catalog, discover, and govern AI agents/MCP servers/tools — covers hybrid search, MCP endpoint, governance workflows, URL-based sync, and cross-service integration patterns
- **Evaluations** (1 file): automated agent quality assessment using LLM-as-a-Judge with online/on-demand modes and built-in/custom evaluators
- **AgentCore Docs MCP server**: bundle `awslabs.amazon-bedrock-agentcore-mcp-server` for in-skill documentation search
- **Security & Resource Policies**: resource-based policies for Runtime/Gateway/Memory, cross-account access, VPC/IP restrictions, complete IAM action reference
- **S3 Files Deployment Guide**: deploy Claude Agent SDK, OpenClaw, and Strands Agents with S3 Files shared filesystem and AgentCore Runtime
- **Runtime enrichment**: agent transformation workflow (`@app.entrypoint`), AgentCore CLI deployment path
- **SKILL.md quality**: third-person description, imperative form, specific trigger phrases, Evaluations quick workflow

### Changes

| Category | Files | Details |
|----------|-------|---------|
| Agent Registry | 6 new | README, getting-started, mcp-endpoint, governance-workflows, sync-configuration, registry-integration |
| Evaluations | 1 new | README with online/on-demand modes, built-in/custom evaluators, IAM |
| Security | 1 new | Resource-based policies, IAM action reference, policy examples |
| S3 Files Guide | 1 new | Claude Agent SDK + OpenClaw + Strands deployment patterns |
| Runtime | 1 modified | Agent transformation, AgentCore CLI, Registry link |
| SKILL.md | 1 modified | 9 services, agentcore-docs MCP, trigger phrases, Evaluations workflow |
| marketplace.json | 1 modified | agentcore-docs MCP server, version bump, keywords |

## Test plan

- [ ] Verify skill loads correctly: `claude -p "List all available skills"`
- [ ] Verify AgentCore MCP server installs: `uvx awslabs.amazon-bedrock-agentcore-mcp-server@latest --help`
- [ ] Verify all internal cross-references resolve (registry ↔ runtime ↔ evaluations ↔ security)
- [ ] Verify descriptor type values match AWS docs (`MCP`, `A2A`, `SKILL`, `CUSTOM`)
- [ ] Verify IAM actions use `bedrock-agentcore:` prefix throughout