### PR TITLE
Fix yanked AWS Labs MCP package references

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -45,19 +45,7 @@
       "strict": false,
       "skills": [
         "./skills/aws-cdk-development"
-      ],
-      "mcpServers": {
-        "cdk": {
-          "type": "stdio",
-          "command": "uvx",
-          "args": [
-            "awslabs.cdk-mcp-server@latest"
-          ],
-          "env": {
-            "FASTMCP_LOG_LEVEL": "ERROR"
-          }
-        }
-      }
+      ]
     },
     {
       "name": "aws-cost-ops",
@@ -88,11 +76,11 @@
             "FASTMCP_LOG_LEVEL": "ERROR"
           }
         },
-        "costexp": {
+        "billing": {
           "type": "stdio",
           "command": "uvx",
           "args": [
-            "awslabs.cost-explorer-mcp-server@latest"
+            "awslabs.billing-cost-management-mcp-server@latest"
           ],
           "env": {
             "FASTMCP_LOG_LEVEL": "ERROR"

--- a/plugins/aws-cdk/skills/aws-cdk-development/SKILL.md
+++ b/plugins/aws-cdk/skills/aws-cdk-development/SKILL.md
@@ -28,19 +28,17 @@ This skill provides comprehensive guidance for developing AWS infrastructure usi
 
 Always verify AWS facts using MCP tools (`mcp__aws-mcp__*` or `mcp__*awsdocs*__*`) before answering. The `aws-mcp-setup` dependency is auto-loaded — if MCP tools are unavailable, guide the user through that skill's setup flow.
 
-## Integrated MCP Servers
+## CDK-Specific MCP Guidance
 
-This skill includes the CDK MCP server automatically configured with the plugin:
+AWS Labs replaced the dedicated CDK MCP server (`awslabs.cdk-mcp-server`) with the broader `awslabs.aws-iac-mcp-server`, which covers CDK alongside CloudFormation and other AWS infrastructure-as-code workflows.
 
-### AWS CDK MCP Server
-**When to use**: For CDK-specific guidance and utilities
-- Get CDK construct recommendations
-- Retrieve CDK best practices
-- Access CDK pattern suggestions
-- Validate CDK configurations
-- Get help with CDK-specific APIs
+For CDK construct lookups, best-practice recommendations, and pattern guidance, install `awslabs.aws-iac-mcp-server`. It ships in the `deploy-on-aws` plugin from `awslabs/agent-plugins`, or can be registered directly with `claude mcp add aws-iac uvx awslabs.aws-iac-mcp-server@latest`.
 
-**Important**: Leverage this server for CDK construct guidance and advanced CDK operations.
+**When to reach for it**:
+- CDK construct recommendations and API lookups
+- CDK and CloudFormation best-practice patterns
+- Validation of synthesized templates
+- Cross-resource configuration guidance
 
 ## When to Use This Skill
 


### PR DESCRIPTION
AWS Labs replaced `awslabs.cdk-mcp-server` and `awslabs.cost-explorer-mcp-server` with consolidated successors. The old packages are no longer installable from PyPI and their source has been removed from `awslabs/mcp`. The marketplace.json still references the old names, so `aws-cdk` and `aws-cost-ops` fail to install on fresh setups.

This PR points the affected entries at the new packages:

- `cdk-mcp-server` is folded into `aws-iac-mcp-server`, which already ships in the `deploy-on-aws` plugin from `awslabs/agent-plugins`. The `aws-cdk` plugin's `mcpServers` block is dropped.
- `cost-explorer-mcp-server` is replaced by `billing-cost-management-mcp-server`. The `aws-cost-ops` plugin's `costexp` entry is renamed to `billing` and points at the new package.

The `aws-cdk-development` skill body section that describes the old CDK MCP server is updated to point readers at the `aws-iac-mcp-server` successor instead.