### PR TITLE
fix(.claude): repoint dev skill symlinks after aws-iac rename

### DIFF
--- a/.claude/skills/aws-cdk-development
+++ b/.claude/skills/aws-cdk-development
@@ -1,1 +1,1 @@
-../../plugins/aws-cdk/skills/aws-cdk-development
+../../plugins/aws-iac/skills/aws-cdk-development

--- a/.claude/skills/aws-sst-development
+++ b/.claude/skills/aws-sst-development
@@ -1,0 +1,1 @@
+../../plugins/aws-iac/skills/aws-sst-development


### PR DESCRIPTION
## Summary
PR #6 renamed `plugins/aws-cdk/` → `plugins/aws-iac/` but the committed local-dev symlinks under `.claude/skills/` weren't updated, so on `main`:
- `.claude/skills/aws-cdk-development` is now a **dead link** (points at the gone `../../plugins/aws-cdk/...`)
- there's no `aws-sst-development` symlink for the new skill

These symlinks are intentionally tracked so cloning this repo lets a local Claude Code session load the in-tree skills (handy for debugging the latest version straight from the repo).

## Changes
- Repoint `aws-cdk-development` → `../../plugins/aws-iac/skills/aws-cdk-development`
- Add `aws-sst-development` → `../../plugins/aws-iac/skills/aws-sst-development`

## Test Plan
- [x] All 6 `.claude/skills/*` symlinks resolve to an existing directory
- [x] Both touched entries are stored as git symlinks (mode `120000`), not regular files
- [x] Targets point at `plugins/aws-iac/` (the post-rename location)